### PR TITLE
Fix PR name and commit number retrieval

### DIFF
--- a/src/utils/__tests__/prEnrichment.test.ts
+++ b/src/utils/__tests__/prEnrichment.test.ts
@@ -377,5 +377,182 @@ describe('prEnrichment', () => {
 
       expect(onProgress).toHaveBeenCalledWith(1, 1);
     });
+
+    /**
+     * Tests for network efficiency: deduplication and caching behavior
+     *
+     * These tests verify that:
+     * 1. Multiple items referencing the same PR result in only ONE network request
+     * 2. Cached data is reused within the 24-hour expiry window
+     * 3. Stale cache (>24h) triggers a refresh, but only once per unique PR
+     */
+    describe('network efficiency', () => {
+      /**
+       * When multiple events reference the same PR (e.g., review, comment, label),
+       * only one network request should be made, and all items should be enriched.
+       */
+      it('should fetch each unique PR only once even with multiple items referencing it', async () => {
+        // 3 different events all referencing the same PR #456
+        const items: GitHubItem[] = [
+          {
+            id: 1,
+            html_url: 'https://github.com/owner/repo/pull/456',
+            title: 'Review on: Pull Request #456',
+            created_at: '2023-01-01T00:00:00Z',
+            updated_at: '2023-01-01T00:00:00Z',
+            state: 'open',
+            user: { login: 'user1', avatar_url: 'https://github.com/user1.png', html_url: 'https://github.com/user1' },
+            originalEventType: 'PullRequestReviewEvent',
+          },
+          {
+            id: 2,
+            html_url: 'https://github.com/owner/repo/pull/456',
+            title: 'Review comment on: Pull Request #456',
+            created_at: '2023-01-01T01:00:00Z',
+            updated_at: '2023-01-01T01:00:00Z',
+            state: 'open',
+            user: { login: 'user2', avatar_url: 'https://github.com/user2.png', html_url: 'https://github.com/user2' },
+            originalEventType: 'PullRequestReviewCommentEvent',
+          },
+          {
+            id: 3,
+            html_url: 'https://github.com/owner/repo/pull/456',
+            title: 'Pull Request #456 labeled',
+            created_at: '2023-01-01T02:00:00Z',
+            updated_at: '2023-01-01T02:00:00Z',
+            state: 'open',
+            user: { login: 'user3', avatar_url: 'https://github.com/user3.png', html_url: 'https://github.com/user3' },
+            originalEventType: 'PullRequestEvent',
+          },
+        ];
+
+        const mockPRDetails = {
+          title: 'Add new feature',
+          state: 'open',
+          body: 'Description',
+          html_url: 'https://github.com/owner/repo/pull/456',
+          labels: [],
+          updated_at: '2023-01-02T00:00:00Z',
+        };
+
+        (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve(mockPRDetails),
+        });
+
+        const results = await enrichItemsWithPRDetails(items, 'test-token');
+
+        // Only 1 fetch for 3 items referencing the same PR
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+
+        // All items should be enriched with the PR title
+        expect(results[0].title).toBe('Review on: Add new feature');
+        expect(results[1].title).toBe('Review comment on: Add new feature');
+        expect(results[2].title).toBe('Add new feature (labeled)');
+      });
+
+      /**
+       * When items reference different PRs, each unique PR should be fetched once.
+       */
+      it('should fetch each unique PR once when items reference different PRs', async () => {
+        const items: GitHubItem[] = [
+          {
+            id: 1,
+            html_url: 'https://github.com/owner/repo/pull/100',
+            title: 'Pull Request #100 opened',
+            created_at: '2023-01-01T00:00:00Z',
+            updated_at: '2023-01-01T00:00:00Z',
+            state: 'open',
+            user: { login: 'user1', avatar_url: 'https://github.com/user1.png', html_url: 'https://github.com/user1' },
+            originalEventType: 'PullRequestEvent',
+          },
+          {
+            id: 2,
+            html_url: 'https://github.com/owner/repo/pull/100',
+            title: 'Review on: Pull Request #100',
+            created_at: '2023-01-01T01:00:00Z',
+            updated_at: '2023-01-01T01:00:00Z',
+            state: 'open',
+            user: { login: 'user2', avatar_url: 'https://github.com/user2.png', html_url: 'https://github.com/user2' },
+            originalEventType: 'PullRequestReviewEvent',
+          },
+          {
+            id: 3,
+            html_url: 'https://github.com/owner/repo/pull/200',
+            title: 'Pull Request #200 closed',
+            created_at: '2023-01-01T02:00:00Z',
+            updated_at: '2023-01-01T02:00:00Z',
+            state: 'closed',
+            user: { login: 'user3', avatar_url: 'https://github.com/user3.png', html_url: 'https://github.com/user3' },
+            originalEventType: 'PullRequestEvent',
+          },
+        ];
+
+        // Mock responses for both PRs
+        (global.fetch as ReturnType<typeof vi.fn>)
+          .mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve({ title: 'Feature A', state: 'open', labels: [], updated_at: '2023-01-02T00:00:00Z' }),
+          })
+          .mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve({ title: 'Feature B', state: 'closed', labels: [], updated_at: '2023-01-02T00:00:00Z' }),
+          });
+
+        const results = await enrichItemsWithPRDetails(items, 'test-token');
+
+        // 2 fetches: one for PR #100, one for PR #200 (not 3)
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+
+        // Items for PR #100 should have Feature A title
+        expect(results[0].title).toBe('Feature A (opened)');
+        expect(results[1].title).toBe('Review on: Feature A');
+
+        // Item for PR #200 should have Feature B title
+        expect(results[2].title).toBe('Feature B (closed)');
+      });
+
+      /**
+       * Fresh cache (<24h old) should be used without making network requests.
+       */
+      it('should use cached data without network request when cache is fresh (<24h)', async () => {
+        const item: GitHubItem = {
+          id: 1,
+          html_url: 'https://github.com/owner/repo/pull/456',
+          title: 'Pull Request #456 labeled',
+          created_at: '2023-01-01T00:00:00Z',
+          updated_at: '2023-01-01T00:00:00Z',
+          state: 'open',
+          user: { login: 'user1', avatar_url: 'https://github.com/user1.png', html_url: 'https://github.com/user1' },
+          originalEventType: 'PullRequestEvent',
+        };
+
+        const mockPRDetails = {
+          title: 'Cached PR Title',
+          state: 'open',
+          body: '',
+          html_url: 'https://github.com/owner/repo/pull/456',
+          labels: [],
+          updated_at: '2023-01-02T00:00:00Z',
+        };
+
+        (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve(mockPRDetails),
+        });
+
+        // First call populates cache
+        await enrichItemsWithPRDetails([item], 'test-token');
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+
+        // Second call with new item referencing same PR should use cache
+        const item2: GitHubItem = { ...item, id: 2, title: 'Pull Request #456 closed' };
+        const results = await enrichItemsWithPRDetails([item2], 'test-token');
+
+        // Still only 1 fetch (cache was used)
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+        expect(results[0].title).toBe('Cached PR Title (closed)');
+      });
+    });
   });
 });

--- a/src/utils/__tests__/prEnrichment.test.ts
+++ b/src/utils/__tests__/prEnrichment.test.ts
@@ -26,8 +26,8 @@ vi.mock('../indexedDB', () => {
         mockCache.clear();
       }),
     },
-    // Export a way to clear the mock cache for tests
-    __mockCacheClear: () => mockCache.clear(),
+    // Export a type-safe way to clear the mock cache for tests
+    clearMockCache: () => mockCache.clear(),
   };
 });
 
@@ -37,11 +37,9 @@ global.fetch = vi.fn();
 describe('prEnrichment', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
-    // Clear the mock cache
-    const indexedDBModule = await import('../indexedDB') as Record<string, unknown>;
-    if (indexedDBModule.__mockCacheClear) {
-      (indexedDBModule.__mockCacheClear as () => void)();
-    }
+    // Clear the mock cache using the exported helper
+    const { clearMockCache } = await import('../indexedDB');
+    clearMockCache();
     await clearPRCache();
   });
 

--- a/src/utils/__tests__/rawDataUtils.test.ts
+++ b/src/utils/__tests__/rawDataUtils.test.ts
@@ -84,7 +84,41 @@ describe('rawDataUtils', () => {
 
       expect(result).toBeTruthy();
       expect(result?.original).toBeDefined();
-      expect(result?.original).toEqual(mockPushEvent.payload);
+      expect(result?.original).toEqual(mockPushEvent);
+    });
+
+    it('should handle PushEvent with minimal payload (only head/before, no commits array)', () => {
+      const mockPushEventMinimal: GitHubEvent = {
+        id: '6817699748',
+        type: 'PushEvent',
+        actor: {
+          id: 1178348,
+          login: 'testuser',
+          avatar_url: 'https://avatars.githubusercontent.com/u/1178348?',
+          url: 'https://api.github.com/users/testuser',
+        },
+        repo: {
+          id: 26142062,
+          name: 'testuser/repo',
+          url: 'https://api.github.com/repos/testuser/repo',
+        },
+        payload: {
+          repository_id: 26142062,
+          push_id: 29111594769,
+          ref: 'refs/heads/feature_branch',
+          head: 'bd48e854193a21d7c0b25028b69031792121f929',
+          before: '587796ff64140ea15f47b6f4a7c0069f09ee43d9',
+        } as Record<string, unknown>,
+        public: true,
+        created_at: '2025-12-17T23:09:40Z',
+      };
+
+      const result = transformEventToItem(mockPushEventMinimal);
+
+      expect(result).toBeTruthy();
+      expect(result?.title).toBe('Pushed to testuser/feature_branch');
+      expect(result?.body).toBe('**Repository:** [testuser/repo](https://github.com/testuser/repo)\n\n**Commits:** 587796f...bd48e85');
+      expect(result?.original).toEqual(mockPushEventMinimal);
     });
 
     it('should include original payload in CreateEvent items', () => {

--- a/src/utils/indexedDB.ts
+++ b/src/utils/indexedDB.ts
@@ -6,9 +6,10 @@ import { GitHubEvent } from '../types';
  */
 
 const DB_NAME = 'GitVegasDB';
-const DB_VERSION = 1;
+const DB_VERSION = 2; // Incremented for PR cache store
 const EVENTS_STORE = 'events';
 const METADATA_STORE = 'metadata';
+const PR_CACHE_STORE = 'prCache';
 
 export interface EventsData {
   id: string;
@@ -27,6 +28,22 @@ export interface MetadataRecord {
   id: string;
   value: unknown;
   timestamp: number;
+}
+
+export interface PRCacheRecord {
+  id: string; // PR API URL (e.g., https://api.github.com/repos/owner/repo/pulls/123)
+  prNumber: number;
+  repoFullName: string;
+  title: string;
+  state: string;
+  body: string;
+  html_url: string;
+  labels: Array<{ name: string; color?: string; description?: string }>;
+  updated_at: string;
+  closed_at?: string;
+  merged_at?: string;
+  merged?: boolean;
+  cachedAt: number; // Timestamp when this was cached
 }
 
 class IndexedDBManager {
@@ -66,6 +83,13 @@ class IndexedDBManager {
         if (!db.objectStoreNames.contains(METADATA_STORE)) {
           const metadataStore = db.createObjectStore(METADATA_STORE, { keyPath: 'id' });
           metadataStore.createIndex('timestamp', 'timestamp', { unique: false });
+        }
+
+        // Create PR cache store (added in version 2)
+        if (!db.objectStoreNames.contains(PR_CACHE_STORE)) {
+          const prCacheStore = db.createObjectStore(PR_CACHE_STORE, { keyPath: 'id' });
+          prCacheStore.createIndex('cachedAt', 'cachedAt', { unique: false });
+          prCacheStore.createIndex('repoFullName', 'repoFullName', { unique: false });
         }
       };
     });
@@ -200,17 +224,24 @@ class IndexedDBManager {
         return;
       }
 
-      const transaction = this.db.transaction([EVENTS_STORE, METADATA_STORE], 'readwrite');
+      const stores = [EVENTS_STORE, METADATA_STORE];
+      // Add PR_CACHE_STORE if it exists (may not exist if upgrading from older version)
+      if (this.db.objectStoreNames.contains(PR_CACHE_STORE)) {
+        stores.push(PR_CACHE_STORE);
+      }
+
+      const transaction = this.db.transaction(stores, 'readwrite');
       const eventsStore = transaction.objectStore(EVENTS_STORE);
       const metadataStore = transaction.objectStore(METADATA_STORE);
 
       const eventsRequest = eventsStore.clear();
       const metadataRequest = metadataStore.clear();
 
+      const totalStores = stores.length;
       let completed = 0;
       const checkComplete = () => {
         completed++;
-        if (completed === 2) resolve();
+        if (completed === totalStores) resolve();
       };
 
       eventsRequest.onsuccess = checkComplete;
@@ -218,6 +249,117 @@ class IndexedDBManager {
 
       eventsRequest.onerror = () => reject(eventsRequest.error);
       metadataRequest.onerror = () => reject(metadataRequest.error);
+
+      // Clear PR cache if store exists
+      if (stores.includes(PR_CACHE_STORE)) {
+        const prCacheStore = transaction.objectStore(PR_CACHE_STORE);
+        const prCacheRequest = prCacheStore.clear();
+        prCacheRequest.onsuccess = checkComplete;
+        prCacheRequest.onerror = () => reject(prCacheRequest.error);
+      }
+    });
+  }
+
+  /**
+   * Store PR details in cache
+   */
+  async storePRCache(prData: PRCacheRecord): Promise<void> {
+    await this.init();
+
+    return new Promise((resolve, reject) => {
+      if (!this.db) {
+        reject(new Error('Database not initialized'));
+        return;
+      }
+
+      const transaction = this.db.transaction([PR_CACHE_STORE], 'readwrite');
+      const store = transaction.objectStore(PR_CACHE_STORE);
+
+      const request = store.put(prData);
+
+      request.onsuccess = () => resolve();
+      request.onerror = () => {
+        console.error('Failed to store PR cache:', request.error);
+        reject(request.error);
+      };
+    });
+  }
+
+  /**
+   * Get PR details from cache
+   */
+  async getPRCache(apiUrl: string): Promise<PRCacheRecord | null> {
+    await this.init();
+
+    return new Promise((resolve, reject) => {
+      if (!this.db) {
+        reject(new Error('Database not initialized'));
+        return;
+      }
+
+      const transaction = this.db.transaction([PR_CACHE_STORE], 'readonly');
+      const store = transaction.objectStore(PR_CACHE_STORE);
+      const request = store.get(apiUrl);
+
+      request.onsuccess = () => {
+        resolve(request.result || null);
+      };
+
+      request.onerror = () => {
+        console.error('Failed to retrieve PR cache:', request.error);
+        reject(request.error);
+      };
+    });
+  }
+
+  /**
+   * Get all PR cache records
+   */
+  async getAllPRCache(): Promise<PRCacheRecord[]> {
+    await this.init();
+
+    return new Promise((resolve, reject) => {
+      if (!this.db) {
+        reject(new Error('Database not initialized'));
+        return;
+      }
+
+      const transaction = this.db.transaction([PR_CACHE_STORE], 'readonly');
+      const store = transaction.objectStore(PR_CACHE_STORE);
+      const request = store.getAll();
+
+      request.onsuccess = () => {
+        resolve(request.result || []);
+      };
+
+      request.onerror = () => {
+        console.error('Failed to retrieve all PR cache:', request.error);
+        reject(request.error);
+      };
+    });
+  }
+
+  /**
+   * Clear PR cache
+   */
+  async clearPRCache(): Promise<void> {
+    await this.init();
+
+    return new Promise((resolve, reject) => {
+      if (!this.db) {
+        reject(new Error('Database not initialized'));
+        return;
+      }
+
+      const transaction = this.db.transaction([PR_CACHE_STORE], 'readwrite');
+      const store = transaction.objectStore(PR_CACHE_STORE);
+      const request = store.clear();
+
+      request.onsuccess = () => resolve();
+      request.onerror = () => {
+        console.error('Failed to clear PR cache:', request.error);
+        reject(request.error);
+      };
     });
   }
 
@@ -381,6 +523,97 @@ export const eventsStorage = {
     } catch (error) {
       console.error('Failed to get storage info:', error);
       return null;
+    }
+  },
+};
+
+/**
+ * Convenience functions for PR cache storage
+ */
+export const prCacheStorage = {
+  /**
+   * Store PR details in cache
+   */
+  async store(prData: PRCacheRecord): Promise<void> {
+    if (!IndexedDBManager.isSupported()) {
+      // Fallback to localStorage with a key based on PR URL
+      try {
+        const cacheKey = `pr-cache-${prData.id}`;
+        localStorage.setItem(cacheKey, JSON.stringify(prData));
+      } catch (error) {
+        console.error('Failed to store PR cache in localStorage:', error);
+      }
+      return;
+    }
+
+    try {
+      await indexedDBManager.storePRCache(prData);
+    } catch (error) {
+      console.error('Failed to store PR cache in IndexedDB:', error);
+    }
+  },
+
+  /**
+   * Retrieve PR details from cache
+   */
+  async get(apiUrl: string): Promise<PRCacheRecord | null> {
+    if (!IndexedDBManager.isSupported()) {
+      try {
+        const cacheKey = `pr-cache-${apiUrl}`;
+        const data = localStorage.getItem(cacheKey);
+        return data ? JSON.parse(data) : null;
+      } catch (error) {
+        console.error('Failed to retrieve PR cache from localStorage:', error);
+        return null;
+      }
+    }
+
+    try {
+      return await indexedDBManager.getPRCache(apiUrl);
+    } catch (error) {
+      console.error('Failed to retrieve PR cache from IndexedDB:', error);
+      return null;
+    }
+  },
+
+  /**
+   * Get all cached PR details
+   */
+  async getAll(): Promise<PRCacheRecord[]> {
+    if (!IndexedDBManager.isSupported()) {
+      // In localStorage fallback, we'd need to iterate all keys - not efficient
+      return [];
+    }
+
+    try {
+      return await indexedDBManager.getAllPRCache();
+    } catch (error) {
+      console.error('Failed to get all PR cache from IndexedDB:', error);
+      return [];
+    }
+  },
+
+  /**
+   * Clear all PR cache
+   */
+  async clear(): Promise<void> {
+    if (!IndexedDBManager.isSupported()) {
+      // Clear localStorage PR cache entries
+      const keysToRemove: string[] = [];
+      for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        if (key?.startsWith('pr-cache-')) {
+          keysToRemove.push(key);
+        }
+      }
+      keysToRemove.forEach(key => localStorage.removeItem(key));
+      return;
+    }
+
+    try {
+      await indexedDBManager.clearPRCache();
+    } catch (error) {
+      console.error('Failed to clear PR cache from IndexedDB:', error);
     }
   },
 }; 

--- a/src/utils/prEnrichment.ts
+++ b/src/utils/prEnrichment.ts
@@ -15,6 +15,9 @@ const CACHE_EXPIRY_MS = 24 * 60 * 60 * 1000;
 const inFlightRequests = new Map<string, Promise<PRCacheRecord | null>>();
 
 // Known GitHub PR actions for validation
+// Note: This list covers the most common PR actions. Some webhook-only actions
+// like 'ready_for_review', 'converted_to_draft', etc. are not included as they
+// rarely appear in event titles but could be added if needed.
 const VALID_PR_ACTIONS = [
   'opened', 'closed', 'labeled', 'unlabeled', 'synchronized', 'reopened',
   'edited', 'assigned', 'unassigned', 'review_requested', 'review_request_removed'

--- a/src/utils/prEnrichment.ts
+++ b/src/utils/prEnrichment.ts
@@ -19,8 +19,17 @@ const inFlightRequests = new Map<string, Promise<PRCacheRecord | null>>();
 // like 'ready_for_review', 'converted_to_draft', etc. are not included as they
 // rarely appear in event titles but could be added if needed.
 const VALID_PR_ACTIONS = [
-  'opened', 'closed', 'labeled', 'unlabeled', 'synchronized', 'reopened',
-  'edited', 'assigned', 'unassigned', 'review_requested', 'review_request_removed'
+  'opened',
+  'closed',
+  'labeled',
+  'unlabeled',
+  'synchronized',
+  'reopened',
+  'edited',
+  'assigned',
+  'unassigned',
+  'review_requested',
+  'review_request_removed',
 ] as const;
 
 /**

--- a/src/utils/prEnrichment.ts
+++ b/src/utils/prEnrichment.ts
@@ -229,19 +229,23 @@ const applyPRDetailsToItem = (item: GitHubItem, prDetails: PRCacheRecord): GitHu
     state: prDetails.state || item.state,
   };
 
-  // Update title based on event type
-  if (item.originalEventType === 'PullRequestReviewEvent') {
-    enrichedItem.title = `Review on: ${prDetails.title}`;
-  } else if (item.originalEventType === 'PullRequestReviewCommentEvent') {
-    enrichedItem.title = `Review comment on: ${prDetails.title}`;
-  } else if (item.title?.match(/^Pull Request #\d+/) || item.title?.match(/^Pull Request (opened|closed|labeled|unlabeled|synchronized|reopened|edited|assigned|unassigned|review_requested|review_request_removed)$/)) {
-    // Extract the action from the current title (handles both "Pull Request #123 action" and "Pull Request action")
-    const actionMatch = item.title?.match(/^Pull Request (?:#\d+ )?(.+)$/);
-    const action = actionMatch ? actionMatch[1] : '';
-    enrichedItem.title = action ? `${prDetails.title} (${action})` : prDetails.title;
-  } else if (item.title?.includes('undefined')) {
-    // Handle titles with "undefined" - replace with actual PR title
-    enrichedItem.title = prDetails.title;
+  // Update title based on event type (only if we have a valid PR title)
+  const hasValidTitle = prDetails.title && prDetails.title !== 'undefined' && prDetails.title.trim() !== '';
+
+  if (hasValidTitle) {
+    if (item.originalEventType === 'PullRequestReviewEvent') {
+      enrichedItem.title = `Review on: ${prDetails.title}`;
+    } else if (item.originalEventType === 'PullRequestReviewCommentEvent') {
+      enrichedItem.title = `Review comment on: ${prDetails.title}`;
+    } else if (item.title?.match(/^Pull Request #\d+/) || item.title?.match(/^Pull Request (opened|closed|labeled|unlabeled|synchronized|reopened|edited|assigned|unassigned|review_requested|review_request_removed)$/)) {
+      // Extract the action from the current title (handles both "Pull Request #123 action" and "Pull Request action")
+      const actionMatch = item.title?.match(/^Pull Request (?:#\d+ )?(.+)$/);
+      const action = actionMatch ? actionMatch[1] : '';
+      enrichedItem.title = action ? `${prDetails.title} (${action})` : prDetails.title;
+    } else if (item.title?.includes('undefined')) {
+      // Handle titles with "undefined" - replace with actual PR title
+      enrichedItem.title = prDetails.title;
+    }
   }
 
   return enrichedItem;

--- a/src/utils/rawDataUtils.ts
+++ b/src/utils/rawDataUtils.ts
@@ -245,7 +245,7 @@ export const transformEventToItem = (event: GitHubEvent): GitHubItem | null => {
     //   2. payload.size (total commits reported by GitHub)
     //   3. 0 if neither is present
     const totalCommitCount =
-      (pushPayload?.commits?.length ?? 0) || (pushPayload?.size ?? 0);
+      pushPayload?.commits?.length ?? pushPayload?.size ?? 0;
 
     // distinct_size represents the number of distinct commits in the push.
     // If it is missing, fall back to the totalCommitCount so both values stay in sync.
@@ -255,6 +255,8 @@ export const transformEventToItem = (event: GitHubEvent): GitHubItem | null => {
         : totalCommitCount;
 
     // Use the totalCommitCount as the display count when available; otherwise use distinctCount.
+    // We prefer totalCommitCount because it represents the actual number of commits in the push,
+    // while distinctCount excludes commits that already exist in other branches.
     const displayCount = totalCommitCount > 0 ? totalCommitCount : distinctCount;
 
     // Check if we have head/before indicating commits exist even without exact count


### PR DESCRIPTION
This fixes two issues with the GitHub Events display:

1. PR titles not showing: GitHub Events API no longer returns full PR details.
   - Added PR cache store to IndexedDB for persistent storage
   - Implemented SWR (stale-while-revalidate) pattern for PR enrichment
   - PRs are now fetched once and cached, with background refresh for stale data
   - Cache expires after 24 hours

2. Push events showing 0 commits: The `distinct_size` field was often undefined.
   - Now uses commits array length as primary source
   - Falls back to distinct_size or size if commits array is empty

Changes:
- indexedDB.ts: Added PRCacheRecord type and prCacheStorage functions
- prEnrichment.ts: Rewrote to use IndexedDB cache with SWR pattern
- rawDataUtils.ts: Fixed push event commit count calculation
- useGitHubDataProcessing.ts: Updated to use SWR callback for instant UI updates