### PR TITLE
Add organization member activity data requests

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ interface FormContextType {
   endDate: string;
   githubToken: string;
   apiMode: 'search' | 'events' | 'summary';
+  organization: string;
   searchText: string;
   setUsername: (username: string) => void;
   setStartDate: (date: string) => void;
@@ -45,6 +46,7 @@ interface FormContextType {
   setApiMode: (
     mode: 'search' | 'events' | 'summary'
   ) => void;
+  setOrganization: (org: string) => void;
   setSearchText: (searchText: string) => void;
   handleSearch: () => void;
   handleUsernameBlur: () => void;
@@ -97,6 +99,7 @@ function App() {
     setEndDate,
     setGithubToken,
     setApiMode,
+    setOrganization,
     handleUsernameBlur,
     validateUsernameFormat,
     addAvatarsToCache,
@@ -117,7 +120,7 @@ function App() {
     clearEvents: clearSearchItems,
   } = useIndexedDBStorage('github-search-items-indexeddb');
 
-  const { username, startDate, endDate, githubToken, apiMode } = formSettings;
+  const { username, startDate, endDate, githubToken, apiMode, organization } = formSettings;
 
   const {
     results,
@@ -145,6 +148,7 @@ function App() {
     githubToken,
     startDate,
     endDate,
+    organization: organization || undefined,
     indexedDBEvents,
     indexedDBSearchItems,
     onError: setError,
@@ -435,12 +439,14 @@ function App() {
             endDate,
             githubToken,
             apiMode,
+            organization: organization || '',
             searchText,
             setUsername,
             setStartDate,
             setEndDate,
             setGithubToken,
             setApiMode,
+            setOrganization,
             setSearchText,
             handleSearch,
             handleUsernameBlur,

--- a/src/components/OrgMemberLookup.tsx
+++ b/src/components/OrgMemberLookup.tsx
@@ -1,0 +1,269 @@
+import React, { useState, useCallback } from 'react';
+import {
+  Box,
+  Button,
+  FormControl,
+  TextInput,
+  Flash,
+  ActionList,
+  ActionMenu,
+  Avatar,
+  Checkbox,
+  Label,
+  Spinner,
+  Text,
+} from '@primer/react';
+import { OrganizationIcon, PeopleIcon } from '@primer/octicons-react';
+import { fetchOrgMembers, FetchOrgMembersResult } from '../utils/githubSearch';
+import { GitHubOrgMember, GitHubOrganization } from '../types';
+
+interface OrgMemberLookupProps {
+  /** Callback when usernames are selected and confirmed */
+  onUsernamesSelected: (usernames: string[]) => void;
+  /** GitHub token for authenticated requests */
+  githubToken?: string;
+  /** Current usernames in the search field */
+  currentUsernames?: string;
+}
+
+/**
+ * Component for looking up GitHub organization members and selecting them
+ * to populate the username search field.
+ */
+export const OrgMemberLookup: React.FC<OrgMemberLookupProps> = ({
+  onUsernamesSelected,
+  githubToken,
+  currentUsernames = '',
+}) => {
+  const [orgName, setOrgName] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [progress, setProgress] = useState<string>('');
+  const [members, setMembers] = useState<GitHubOrgMember[]>([]);
+  const [organization, setOrganization] = useState<GitHubOrganization | null>(null);
+  const [selectedMembers, setSelectedMembers] = useState<Set<string>>(new Set());
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleFetchMembers = useCallback(async () => {
+    if (!orgName.trim()) {
+      setError('Please enter an organization name');
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    setProgress('');
+    setMembers([]);
+    setOrganization(null);
+    setSelectedMembers(new Set());
+
+    try {
+      const result: FetchOrgMembersResult = await fetchOrgMembers(
+        orgName.trim(),
+        githubToken,
+        setProgress
+      );
+
+      setMembers(result.members);
+      setOrganization(result.organization);
+      // Select all members by default
+      setSelectedMembers(new Set(result.members.map(m => m.login)));
+      setIsOpen(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch organization members');
+    } finally {
+      setLoading(false);
+      setProgress('');
+    }
+  }, [orgName, githubToken]);
+
+  const handleToggleMember = useCallback((login: string) => {
+    setSelectedMembers(prev => {
+      const newSet = new Set(prev);
+      if (newSet.has(login)) {
+        newSet.delete(login);
+      } else {
+        newSet.add(login);
+      }
+      return newSet;
+    });
+  }, []);
+
+  const handleSelectAll = useCallback(() => {
+    setSelectedMembers(new Set(members.map(m => m.login)));
+  }, [members]);
+
+  const handleSelectNone = useCallback(() => {
+    setSelectedMembers(new Set());
+  }, []);
+
+  const handleConfirmSelection = useCallback(() => {
+    const selectedUsernames = Array.from(selectedMembers);
+    if (selectedUsernames.length > 0) {
+      // Merge with existing usernames
+      const existingUsernames = currentUsernames
+        .split(',')
+        .map(u => u.trim())
+        .filter(u => u);
+      const allUsernames = [...new Set([...existingUsernames, ...selectedUsernames])];
+      onUsernamesSelected(allUsernames);
+    }
+    setIsOpen(false);
+  }, [selectedMembers, currentUsernames, onUsernamesSelected]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        handleFetchMembers();
+      }
+    },
+    [handleFetchMembers]
+  );
+
+  return (
+    <Box>
+      <ActionMenu open={isOpen} onOpenChange={setIsOpen}>
+        <ActionMenu.Anchor>
+          <Box
+            sx={{
+              display: 'flex',
+              gap: 2,
+              alignItems: 'flex-end',
+            }}
+          >
+            <FormControl>
+              <FormControl.Label>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <OrganizationIcon size={16} />
+                  Organization Members Lookup
+                </Box>
+              </FormControl.Label>
+              <TextInput
+                placeholder="Enter organization name (e.g., facebook)"
+                value={orgName}
+                onChange={e => setOrgName(e.target.value)}
+                onKeyDown={handleKeyDown}
+                disabled={loading}
+                sx={{ minWidth: '250px' }}
+              />
+            </FormControl>
+            <Button
+              onClick={handleFetchMembers}
+              disabled={loading || !orgName.trim()}
+              leadingVisual={loading ? Spinner : PeopleIcon}
+            >
+              {loading ? 'Loading...' : 'Fetch Members'}
+            </Button>
+          </Box>
+        </ActionMenu.Anchor>
+
+        <ActionMenu.Overlay width="large">
+          <Box sx={{ p: 3, maxHeight: '500px', overflow: 'auto' }}>
+            {organization && (
+              <Box sx={{ mb: 3, display: 'flex', alignItems: 'center', gap: 2 }}>
+                <Avatar src={organization.avatar_url} size={40} />
+                <Box>
+                  <Text sx={{ fontWeight: 'bold', display: 'block' }}>
+                    {organization.login}
+                  </Text>
+                  {organization.description && (
+                    <Text sx={{ color: 'fg.muted', fontSize: 1 }}>
+                      {organization.description}
+                    </Text>
+                  )}
+                </Box>
+              </Box>
+            )}
+
+            {members.length > 0 && (
+              <>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    mb: 2,
+                    pb: 2,
+                    borderBottom: '1px solid',
+                    borderColor: 'border.default',
+                  }}
+                >
+                  <Text sx={{ fontWeight: 'bold' }}>
+                    {selectedMembers.size} of {members.length} members selected
+                  </Text>
+                  <Box sx={{ display: 'flex', gap: 2 }}>
+                    <Button size="small" onClick={handleSelectAll}>
+                      Select All
+                    </Button>
+                    <Button size="small" onClick={handleSelectNone}>
+                      Select None
+                    </Button>
+                  </Box>
+                </Box>
+
+                <ActionList>
+                  {members.map(member => (
+                    <ActionList.Item
+                      key={member.id}
+                      onSelect={() => handleToggleMember(member.login)}
+                    >
+                      <ActionList.LeadingVisual>
+                        <Checkbox
+                          checked={selectedMembers.has(member.login)}
+                          onChange={() => {}} // Handled by onSelect
+                        />
+                      </ActionList.LeadingVisual>
+                      <Avatar src={member.avatar_url} size={20} sx={{ mr: 2 }} />
+                      <Text>{member.login}</Text>
+                      {member.site_admin && (
+                        <Label sx={{ ml: 2 }} variant="accent">
+                          Admin
+                        </Label>
+                      )}
+                    </ActionList.Item>
+                  ))}
+                </ActionList>
+
+                <Box
+                  sx={{
+                    mt: 3,
+                    pt: 2,
+                    borderTop: '1px solid',
+                    borderColor: 'border.default',
+                    display: 'flex',
+                    justifyContent: 'flex-end',
+                    gap: 2,
+                  }}
+                >
+                  <Button onClick={() => setIsOpen(false)}>Cancel</Button>
+                  <Button
+                    variant="primary"
+                    onClick={handleConfirmSelection}
+                    disabled={selectedMembers.size === 0}
+                  >
+                    Add {selectedMembers.size} Member{selectedMembers.size !== 1 ? 's' : ''} to Search
+                  </Button>
+                </Box>
+              </>
+            )}
+          </Box>
+        </ActionMenu.Overlay>
+      </ActionMenu>
+
+      {loading && progress && (
+        <Text sx={{ mt: 2, color: 'fg.muted', fontSize: 1, display: 'block' }}>
+          {progress}
+        </Text>
+      )}
+
+      {error && (
+        <Flash variant="danger" sx={{ mt: 2 }}>
+          {error}
+        </Flash>
+      )}
+    </Box>
+  );
+};
+
+export default OrgMemberLookup;

--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -9,6 +9,7 @@ import {
 } from '@primer/react';
 import { useFormContext } from '../App';
 import { validateUsernameList, validateGitHubUsernames } from '../utils';
+import { OrgMemberLookup } from './OrgMemberLookup';
 
 const SearchForm = memo(function SearchForm() {
   const {
@@ -43,6 +44,19 @@ const SearchForm = memo(function SearchForm() {
       // Removed localStorage saving - now only saves when validation passes
     },
     [setUsername]
+  );
+
+  // Handle usernames selected from organization lookup
+  const handleOrgUsernamesSelected = useCallback(
+    (usernames: string[]) => {
+      const newUsername = usernames.join(', ');
+      setUsername(newUsername);
+      // Clear any existing errors
+      validateUsernameFormat('');
+      // Save to localStorage
+      localStorage.setItem('github-username', newUsername);
+    },
+    [setUsername, validateUsernameFormat]
   );
 
   const handleUsernameBlurEvent = useCallback(
@@ -200,13 +214,23 @@ const SearchForm = memo(function SearchForm() {
                 textAlign: 'center',
               }}
             >
-              {pendingSearch && isValidating ? 'Validating & queued' 
-               : isValidating ? 'Validating...' 
-               : loading ? 'Loading...' 
+              {pendingSearch && isValidating ? 'Validating & queued'
+               : isValidating ? 'Validating...'
+               : loading ? 'Loading...'
                : 'Update'}
             </Button>
           </FormControl>
         </Box>
+
+        {/* Organization Member Lookup */}
+        <Box sx={{ mt: 2 }}>
+          <OrgMemberLookup
+            onUsernamesSelected={handleOrgUsernamesSelected}
+            githubToken={githubToken}
+            currentUsernames={username}
+          />
+        </Box>
+
         {/* API Mode Switch */}
         <Box 
           sx={{ 

--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -9,7 +9,7 @@ import {
 } from '@primer/react';
 import { useFormContext } from '../App';
 import { validateUsernameList, validateGitHubUsernames } from '../utils';
-import { OrgMemberLookup } from './OrgMemberLookup';
+import { OrgActivityFilter } from './OrgMemberLookup';
 
 const SearchForm = memo(function SearchForm() {
   const {
@@ -21,6 +21,8 @@ const SearchForm = memo(function SearchForm() {
     setEndDate,
     apiMode,
     setApiMode,
+    organization,
+    setOrganization,
     handleSearch,
     handleUsernameBlur,
     validateUsernameFormat,
@@ -44,19 +46,6 @@ const SearchForm = memo(function SearchForm() {
       // Removed localStorage saving - now only saves when validation passes
     },
     [setUsername]
-  );
-
-  // Handle usernames selected from organization lookup
-  const handleOrgUsernamesSelected = useCallback(
-    (usernames: string[]) => {
-      const newUsername = usernames.join(', ');
-      setUsername(newUsername);
-      // Clear any existing errors
-      validateUsernameFormat('');
-      // Save to localStorage
-      localStorage.setItem('github-username', newUsername);
-    },
-    [setUsername, validateUsernameFormat]
   );
 
   const handleUsernameBlurEvent = useCallback(
@@ -222,12 +211,12 @@ const SearchForm = memo(function SearchForm() {
           </FormControl>
         </Box>
 
-        {/* Organization Member Lookup */}
+        {/* Organization Activity Filter */}
         <Box sx={{ mt: 2 }}>
-          <OrgMemberLookup
-            onUsernamesSelected={handleOrgUsernamesSelected}
+          <OrgActivityFilter
+            organization={organization}
+            onOrganizationChange={setOrganization}
             githubToken={githubToken}
-            currentUsernames={username}
           />
         </Box>
 

--- a/src/hooks/useGitHubFormState.ts
+++ b/src/hooks/useGitHubFormState.ts
@@ -20,6 +20,7 @@ interface UseGitHubFormStateReturn {
   setEndDate: (endDate: string) => void;
   setGithubToken: (githubToken: string) => void;
   setApiMode: (apiMode: 'search' | 'events' | 'summary') => void;
+  setOrganization: (organization: string) => void;
   handleUsernameBlur: () => Promise<void>;
   validateUsernameFormat: (username: string) => void;
   addAvatarsToCache: (avatarUrls: { [username: string]: string }) => void;
@@ -49,6 +50,7 @@ export const useGitHubFormState = (onUrlParamsProcessed?: () => void): UseGitHub
       endDate: new Date().toISOString().split('T')[0],
       githubToken: '',
       apiMode: 'summary',
+      organization: '',
     },
     () => {
       setFromUrlParams(true);
@@ -207,6 +209,13 @@ export const useGitHubFormState = (onUrlParamsProcessed?: () => void): UseGitHub
     [setFormSettings]
   );
 
+  const setOrganization = useCallback(
+    (organization: string) => {
+      setFormSettings(prev => ({ ...prev, organization }));
+    },
+    [setFormSettings]
+  );
+
   // Real-time username format validation
   const validateUsernameFormat = useCallback(
     (usernameString: string) => {
@@ -240,6 +249,7 @@ export const useGitHubFormState = (onUrlParamsProcessed?: () => void): UseGitHub
     setEndDate,
     setGithubToken,
     setApiMode,
+    setOrganization,
     handleUsernameBlur,
     validateUsernameFormat,
     addAvatarsToCache,

--- a/src/types.ts
+++ b/src/types.ts
@@ -263,6 +263,8 @@ export interface FormSettings {
   endDate: string;
   githubToken: string;
   apiMode: 'search' | 'events' | 'summary';
+  /** Organization to filter results by (optional) */
+  organization?: string;
 }
 
 // UI/Display settings that control how data is presented

--- a/src/types.ts
+++ b/src/types.ts
@@ -284,6 +284,26 @@ export interface UsernameCache {
   lastFetched: Map<string, number>; // Track when each username was last validated
 }
 
+// GitHub Organization types
+export interface GitHubOrgMember {
+  login: string;
+  id: number;
+  avatar_url: string;
+  html_url: string;
+  type: string;
+  site_admin: boolean;
+}
+
+export interface GitHubOrganization {
+  login: string;
+  id: number;
+  description: string | null;
+  avatar_url: string;
+  html_url: string;
+  public_members_url: string;
+  members_url: string;
+}
+
 
 
 


### PR DESCRIPTION
This feature allows users to fetch and select GitHub organization members to query their issues, PRs, and events. The implementation includes:

- New OrgMemberLookup component with member selection UI
- GitHub API functions to validate orgs and fetch members (with pagination)
- Support for both public and authenticated member endpoints
- Integration with the existing SearchForm to populate usernames
- New TypeScript types for organization and member data