### PR TITLE
Add event data to action information

### DIFF
--- a/src/components/DescriptionDialog.tsx
+++ b/src/components/DescriptionDialog.tsx
@@ -3,6 +3,7 @@ import {
   Box,
   Dialog,
   IconButton,
+  Label,
   Link,
   Text,
   UnderlineNav,
@@ -16,6 +17,7 @@ import {
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { GitHubItem } from '../types';
+import { getActionVariant } from '../utils/actionUtils';
 
 interface DescriptionDialogProps {
   item: GitHubItem | null;
@@ -136,6 +138,36 @@ const DescriptionDialog = memo(function DescriptionDialog({
         display: 'flex',
         flexDirection: 'column'
       }}>
+        {/* Event Metadata */}
+        {(item.action || item.originalEventType) && (
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 2,
+              mb: 3,
+              flexWrap: 'wrap'
+            }}
+          >
+            {item.action && (
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <Text sx={{ fontSize: 0, color: 'fg.muted' }}>Action:</Text>
+                <Label variant={getActionVariant(item.action)} size="small">
+                  {item.action}
+                </Label>
+              </Box>
+            )}
+            {item.originalEventType && (
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <Text sx={{ fontSize: 0, color: 'fg.muted' }}>Event:</Text>
+                <Label variant="secondary" size="small">
+                  {item.originalEventType}
+                </Label>
+              </Box>
+            )}
+          </Box>
+        )}
+
         {/* View Mode Toggle */}
         <Box sx={{ mb: 3 }}>
           <UnderlineNav aria-label="View mode">

--- a/src/components/ItemRow.tsx
+++ b/src/components/ItemRow.tsx
@@ -1,25 +1,14 @@
-import { Box, Avatar, Link, Text, Checkbox, Token, Label } from '@primer/react';
+import { Box, Avatar, AvatarStack, Link, Text, Checkbox, Token, Label } from '@primer/react';
 import { GitHubItem } from '../types';
 import ActionButtonsRow from './ActionButtonsRow';
 import { getActionVariant } from '../utils/actionUtils';
 
-// Helper functions to determine display avatar and user
-const getDisplayAvatar = (item: GitHubItem): string => {
-  // For issues that have an assignee and the user is not the author, show assignee avatar
-  if (!item.pull_request && item.assignee && item.assignee.login !== item.user.login) {
-    return item.assignee.avatar_url;
-  }
-  // Otherwise show the author avatar
-  return item.user.avatar_url;
-};
+// Helper to check if item is an issue (not a PR)
+const isIssue = (item: GitHubItem): boolean => !item.pull_request;
 
-const getDisplayUser = (item: GitHubItem): string => {
-  // For issues that have an assignee and the user is not the author, show assignee name
-  if (!item.pull_request && item.assignee && item.assignee.login !== item.user.login) {
-    return item.assignee.login;
-  }
-  // Otherwise show the author name
-  return item.user.login;
+// Helper to check if issue has a different assignee than the actor
+const hasDistinctAssignee = (item: GitHubItem): boolean => {
+  return isIssue(item) && !!item.assignee && item.assignee.login !== item.user.login;
 };
 import {
   GitMergeIcon,
@@ -158,12 +147,28 @@ const ItemRow = ({
             </Box>
           )}
 
-          <Avatar
-            src={getDisplayAvatar(item)}
-            alt={`${getDisplayUser(item)}'s avatar`}
-            size={size === 'small' ? 24 : 32}
-            sx={{ flexShrink: 0 }}
-          />
+          {/* Avatar(s) - show actor first, then assignee if different for issues */}
+          {hasDistinctAssignee(item) ? (
+            <AvatarStack disableExpand>
+              <Avatar
+                src={item.user.avatar_url}
+                alt={`${item.user.login}'s avatar (actor)`}
+                size={size === 'small' ? 24 : 32}
+              />
+              <Avatar
+                src={item.assignee!.avatar_url}
+                alt={`${item.assignee!.login}'s avatar (assignee)`}
+                size={size === 'small' ? 24 : 32}
+              />
+            </AvatarStack>
+          ) : (
+            <Avatar
+              src={item.user.avatar_url}
+              alt={`${item.user.login}'s avatar`}
+              size={size === 'small' ? 24 : 32}
+              sx={{ flexShrink: 0 }}
+            />
+          )}
 
           {/* Main content - takes remaining space */}
           <Box sx={{ flex: 1, minWidth: 0 }}>
@@ -335,11 +340,27 @@ const ItemRow = ({
               </Box>
             )}
 
-            <Avatar
-              src={getDisplayAvatar(item)}
-              alt={`${getDisplayUser(item)}'s avatar`}
-              size={size === 'small' ? 24 : 32}
-            />
+            {/* Avatar(s) - show actor first, then assignee if different for issues */}
+            {hasDistinctAssignee(item) ? (
+              <AvatarStack disableExpand>
+                <Avatar
+                  src={item.user.avatar_url}
+                  alt={`${item.user.login}'s avatar (actor)`}
+                  size={size === 'small' ? 24 : 32}
+                />
+                <Avatar
+                  src={item.assignee!.avatar_url}
+                  alt={`${item.assignee!.login}'s avatar (assignee)`}
+                  size={size === 'small' ? 24 : 32}
+                />
+              </AvatarStack>
+            ) : (
+              <Avatar
+                src={item.user.avatar_url}
+                alt={`${item.user.login}'s avatar`}
+                size={size === 'small' ? 24 : 32}
+              />
+            )}
 
             {/* Main content */}
             <Box sx={{ flex: 1, minWidth: 0 }}>

--- a/src/components/ItemRow.tsx
+++ b/src/components/ItemRow.tsx
@@ -1,6 +1,7 @@
-import { Box, Avatar, Link, Text, Checkbox, Token } from '@primer/react';
+import { Box, Avatar, Link, Text, Checkbox, Token, Label } from '@primer/react';
 import { GitHubItem } from '../types';
 import ActionButtonsRow from './ActionButtonsRow';
+import { getActionVariant } from '../utils/actionUtils';
 
 // Helper functions to determine display avatar and user
 const getDisplayAvatar = (item: GitHubItem): string => {
@@ -186,6 +187,15 @@ const ItemRow = ({
                   sx={{ flexShrink: 0 }}
                 />
               )}
+              {item.action && (
+                <Label
+                  variant={getActionVariant(item.action)}
+                  size="small"
+                  sx={{ flexShrink: 0 }}
+                >
+                  {item.action}
+                </Label>
+              )}
             </Box>
           </Box>
 
@@ -351,6 +361,15 @@ const ItemRow = ({
                     size="small"
                     sx={{ flexShrink: 0 }}
                   />
+                )}
+                {item.action && (
+                  <Label
+                    variant={getActionVariant(item.action)}
+                    size="small"
+                    sx={{ flexShrink: 0 }}
+                  >
+                    {item.action}
+                  </Label>
                 )}
               </Box>
             </Box>

--- a/src/components/ItemRow.tsx
+++ b/src/components/ItemRow.tsx
@@ -1,4 +1,11 @@
 import { Box, Avatar, AvatarStack, Link, Text, Checkbox, Token, Label } from '@primer/react';
+import {
+  GitMergeIcon,
+  GitPullRequestIcon,
+  GitPullRequestDraftIcon,
+  IssueOpenedIcon,
+  RepoIcon,
+} from '@primer/octicons-react';
 import { GitHubItem } from '../types';
 import ActionButtonsRow from './ActionButtonsRow';
 import { getActionVariant } from '../utils/actionUtils';
@@ -10,13 +17,6 @@ const isIssue = (item: GitHubItem): boolean => !item.pull_request;
 const hasDistinctAssignee = (item: GitHubItem): boolean => {
   return isIssue(item) && !!item.assignee && item.assignee.login !== item.user.login;
 };
-import {
-  GitMergeIcon,
-  GitPullRequestIcon,
-  GitPullRequestDraftIcon,
-  IssueOpenedIcon,
-  RepoIcon,
-} from '@primer/octicons-react';
 
 interface ItemRowProps {
   item: GitHubItem;

--- a/src/components/__tests__/ItemRow.test.tsx
+++ b/src/components/__tests__/ItemRow.test.tsx
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@primer/react';
+import ItemRow from '../ItemRow';
+import { GitHubItem } from '../../types';
+
+// Helper to create a minimal GitHubItem
+const createMockItem = (overrides: Partial<GitHubItem> = {}): GitHubItem => ({
+  id: 1,
+  html_url: 'https://github.com/test/repo/issues/1',
+  title: 'Test Issue',
+  created_at: '2024-01-15T00:00:00Z',
+  updated_at: '2024-01-16T00:00:00Z',
+  state: 'open',
+  user: {
+    login: 'actor-user',
+    avatar_url: 'https://github.com/actor-user.png',
+    html_url: 'https://github.com/actor-user',
+  },
+  ...overrides,
+});
+
+// Helper to render with ThemeProvider
+const renderWithTheme = (component: React.ReactNode) => {
+  return render(<ThemeProvider>{component}</ThemeProvider>);
+};
+
+describe('ItemRow', () => {
+  const mockOnShowDescription = vi.fn();
+
+  describe('Avatar display for issues', () => {
+    it('should show actor avatar for issue without assignee', () => {
+      const item = createMockItem();
+
+      renderWithTheme(
+        <ItemRow item={item} onShowDescription={mockOnShowDescription} />
+      );
+
+      // Should show actor's avatar
+      const avatars = screen.getAllByRole('img');
+      expect(avatars.length).toBeGreaterThanOrEqual(1);
+      expect(avatars[0]).toHaveAttribute('alt', expect.stringContaining('actor-user'));
+    });
+
+    it('should show actor avatar for issue with same user as assignee', () => {
+      const item = createMockItem({
+        assignee: {
+          login: 'actor-user', // Same as user
+          avatar_url: 'https://github.com/actor-user.png',
+          html_url: 'https://github.com/actor-user',
+        },
+      });
+
+      renderWithTheme(
+        <ItemRow item={item} onShowDescription={mockOnShowDescription} />
+      );
+
+      // Should show only actor's avatar (no stack needed)
+      const avatars = screen.getAllByRole('img');
+      expect(avatars[0]).toHaveAttribute('alt', expect.stringContaining('actor-user'));
+    });
+
+    it('should show avatar stack for issue with different assignee', () => {
+      const item = createMockItem({
+        assignee: {
+          login: 'assignee-user',
+          avatar_url: 'https://github.com/assignee-user.png',
+          html_url: 'https://github.com/assignee-user',
+        },
+      });
+
+      renderWithTheme(
+        <ItemRow item={item} onShowDescription={mockOnShowDescription} />
+      );
+
+      // Should show both avatars - actor first, then assignee
+      const avatars = screen.getAllByRole('img');
+      // First avatar should be actor
+      const actorAvatar = avatars.find(img => img.getAttribute('alt')?.includes('actor-user'));
+      const assigneeAvatar = avatars.find(img => img.getAttribute('alt')?.includes('assignee-user'));
+
+      expect(actorAvatar).toBeDefined();
+      expect(assigneeAvatar).toBeDefined();
+    });
+
+    it('should show actor (who performed action) first in avatar stack', () => {
+      const item = createMockItem({
+        action: 'labeled',
+        assignee: {
+          login: 'assignee-user',
+          avatar_url: 'https://github.com/assignee-user.png',
+          html_url: 'https://github.com/assignee-user',
+        },
+      });
+
+      renderWithTheme(
+        <ItemRow item={item} onShowDescription={mockOnShowDescription} />
+      );
+
+      // Verify actor avatar alt text indicates they are the actor
+      const actorAvatar = screen.getAllByRole('img').find(
+        img => img.getAttribute('alt')?.includes('actor') && img.getAttribute('alt')?.includes('actor-user')
+      );
+      expect(actorAvatar).toBeDefined();
+    });
+  });
+
+  describe('Avatar display for PRs', () => {
+    it('should show single avatar for PR (not use avatar stack)', () => {
+      const item = createMockItem({
+        pull_request: { url: 'https://github.com/test/repo/pull/1' },
+        assignee: {
+          login: 'assignee-user',
+          avatar_url: 'https://github.com/assignee-user.png',
+          html_url: 'https://github.com/assignee-user',
+        },
+      });
+
+      renderWithTheme(
+        <ItemRow item={item} onShowDescription={mockOnShowDescription} />
+      );
+
+      // For PRs, should show user avatar (not assignee stack)
+      const avatars = screen.getAllByRole('img');
+      expect(avatars[0]).toHaveAttribute('alt', expect.stringContaining('actor-user'));
+      // Should not show assignee avatar in alt text
+      const assigneeAvatar = avatars.find(img =>
+        img.getAttribute('alt')?.includes('assignee-user') && img.getAttribute('alt')?.includes('assignee')
+      );
+      expect(assigneeAvatar).toBeUndefined();
+    });
+  });
+
+  describe('Action badge display', () => {
+    it('should display action badge when action is present', () => {
+      const item = createMockItem({
+        action: 'labeled',
+      });
+
+      renderWithTheme(
+        <ItemRow item={item} onShowDescription={mockOnShowDescription} />
+      );
+
+      // Should show the action as a label/badge (appears in both mobile and desktop layouts)
+      const actionBadges = screen.getAllByText('labeled');
+      expect(actionBadges.length).toBeGreaterThan(0);
+    });
+
+    it('should not display action badge when action is not present', () => {
+      const item = createMockItem({
+        action: undefined,
+      });
+
+      renderWithTheme(
+        <ItemRow item={item} onShowDescription={mockOnShowDescription} />
+      );
+
+      // Common action words should not appear
+      expect(screen.queryByText('labeled')).not.toBeInTheDocument();
+      expect(screen.queryByText('opened')).not.toBeInTheDocument();
+      expect(screen.queryByText('closed')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export interface GitHubItem {
   event_id?: string;
   html_url: string;
   title: string;
+  action?: string; // Action that triggered the event (e.g., 'opened', 'closed', 'reopened', 'synchronize')
   pull_request?: {
     merged_at?: string;
     url?: string;

--- a/src/utils/actionUtils.ts
+++ b/src/utils/actionUtils.ts
@@ -1,0 +1,43 @@
+/**
+ * Utilities for handling GitHub event actions
+ */
+
+export type LabelVariant = 'default' | 'primary' | 'secondary' | 'accent' | 'success' | 'attention' | 'severe' | 'danger' | 'done' | 'sponsors';
+
+/**
+ * Get the appropriate Primer Label color variant for a GitHub event action
+ *
+ * @param action - The action string from the GitHub event (e.g., 'opened', 'closed', 'merged')
+ * @returns The Primer Label variant to use for styling
+ */
+export const getActionVariant = (action: string | undefined): LabelVariant => {
+  if (!action) return 'secondary';
+
+  switch (action.toLowerCase()) {
+    case 'opened':
+    case 'created':
+    case 'forked':
+      return 'success';
+    case 'closed':
+    case 'deleted':
+      return 'danger';
+    case 'merged':
+      return 'done';
+    case 'synchronize':
+    case 'pushed':
+      return 'accent';
+    case 'reopened':
+    case 'ready_for_review':
+      return 'attention';
+    case 'submitted':
+    case 'edited':
+    case 'labeled':
+    case 'assigned':
+      return 'secondary';
+    case 'started':
+    case 'publicized':
+      return 'sponsors';
+    default:
+      return 'secondary';
+  }
+};

--- a/src/utils/prEnrichment.ts
+++ b/src/utils/prEnrichment.ts
@@ -275,8 +275,8 @@ const applyPRDetailsToItem = (item: GitHubItem, prDetails: PRCacheRecord): GitHu
       // Check if title has a generic PR pattern with action
       const action = matchGenericPRAction(item.title);
       if (action) {
-        // Use the actual PR title with the action appended
-        enrichedItem.title = `${prDetails.title} (${action})`;
+        // Use the actual PR title only - action is displayed separately as a badge
+        enrichedItem.title = prDetails.title;
       } else if (item.title?.includes('undefined')) {
         // Handle titles with "undefined" - replace with actual PR title
         enrichedItem.title = prDetails.title;

--- a/src/utils/rawDataUtils.ts
+++ b/src/utils/rawDataUtils.ts
@@ -271,15 +271,15 @@ export const transformEventToItem = (event: GitHubEvent): GitHubItem | null => {
     const repoOwner = repo.name.split('/')[0];
     let title: string;
     if (displayCount > 0) {
-      title = `Pushed ${displayCount} commit${displayCount !== 1 ? 's' : ''} to ${repoOwner}/${branch}`;
+      title = `Committed ${displayCount} commit${displayCount !== 1 ? 's' : ''} to ${repoOwner}/${branch}`;
       if (distinctCount > 0 && totalCommitCount > distinctCount) {
         title += ` (${distinctCount} distinct)`;
       }
     } else if (hasCommitIndicator) {
       // We know commits were pushed but don't have the count
-      title = `Pushed to ${repoOwner}/${branch}`;
+      title = `Committed to ${repoOwner}/${branch}`;
     } else {
-      title = `Pushed 0 commits to ${repoOwner}/${branch}`;
+      title = `Committed 0 commits to ${repoOwner}/${branch}`;
     }
     
     // Create a body with commit messages if available, or show commit range

--- a/src/utils/rawDataUtils.ts
+++ b/src/utils/rawDataUtils.ts
@@ -55,6 +55,7 @@ export const transformEventToItem = (event: GitHubEvent): GitHubItem | null => {
       event_id: event.id,
       html_url: issue.html_url,
       title: issue.title,
+      action: payload.action, // e.g., 'opened', 'closed', 'reopened', 'labeled', 'assigned'
       created_at: event.created_at, // Use event timestamp, not issue timestamp
       updated_at: issue.updated_at,
       state: issue.state,
@@ -98,6 +99,7 @@ export const transformEventToItem = (event: GitHubEvent): GitHubItem | null => {
       event_id: event.id,
       html_url: htmlUrl,
       title: title,
+      action: payloadWithAction.action, // e.g., 'opened', 'closed', 'reopened', 'synchronize', 'ready_for_review'
       created_at: event.created_at, // Use event timestamp, not PR timestamp
       updated_at: pr.updated_at || event.created_at,
       state: pr.state || 'open',
@@ -142,6 +144,7 @@ export const transformEventToItem = (event: GitHubEvent): GitHubItem | null => {
       event_id: event.id,
       html_url: htmlUrl,
       title: `Review on: ${prTitle}`,
+      action: payloadWithAction.action, // e.g., 'submitted', 'edited', 'dismissed'
       created_at: event.created_at, // Use event timestamp, not PR timestamp
       updated_at: pr.updated_at || event.created_at,
       state: pr.state || 'open',
@@ -172,6 +175,7 @@ export const transformEventToItem = (event: GitHubEvent): GitHubItem | null => {
       event_id: event.id,
       html_url: comment.html_url,
       title: `Comment on: ${issue.title}`,
+      action: payload.action, // e.g., 'created', 'edited', 'deleted'
       created_at: event.created_at, // Use event timestamp, not comment timestamp
       updated_at: comment.updated_at,
       state: issue.state,
@@ -212,6 +216,7 @@ export const transformEventToItem = (event: GitHubEvent): GitHubItem | null => {
       event_id: event.id,
       html_url: comment.html_url,
       title: `Review comment on: ${prTitle}`,
+      action: payloadWithAction.action, // e.g., 'created', 'edited', 'deleted'
       created_at: event.created_at, // Use event timestamp, not comment timestamp
       updated_at: comment.updated_at,
       state: pr.state || 'open',
@@ -302,6 +307,7 @@ export const transformEventToItem = (event: GitHubEvent): GitHubItem | null => {
       event_id: event.id,
       html_url: `https://github.com/${repo.name}/commits/${branch}`,
       title: title,
+      action: 'pushed', // PushEvent doesn't have payload.action, using semantic action
       created_at: event.created_at,
       updated_at: event.created_at, // Push events don't have updated_at, use created_at
       state: 'open', // Push events are always "open"
@@ -344,6 +350,7 @@ export const transformEventToItem = (event: GitHubEvent): GitHubItem | null => {
       event_id: event.id,
       html_url: htmlUrl,
       title: title,
+      action: 'created', // CreateEvent doesn't have payload.action, using semantic action
       created_at: event.created_at,
       updated_at: event.created_at,
       state: 'open',
@@ -369,6 +376,7 @@ export const transformEventToItem = (event: GitHubEvent): GitHubItem | null => {
       event_id: event.id,
       html_url: forkeeUrl,
       title: `Forked repository to ${forkeeName}`,
+      action: 'forked', // ForkEvent doesn't have payload.action, using semantic action
       created_at: event.created_at,
       updated_at: event.created_at,
       state: 'open',
@@ -386,12 +394,13 @@ export const transformEventToItem = (event: GitHubEvent): GitHubItem | null => {
   } else if (type === 'WatchEvent') {
     // Handle WatchEvent - create a GitHubItem from watch event data
     const action = payload?.action || 'starred';
-    
+
     return {
       id: parseInt(event.id),
       event_id: event.id,
       html_url: `https://github.com/${repo.name}`,
       title: `${action === 'started' ? 'Starred' : 'Unstarred'} repository`,
+      action: action, // e.g., 'started' (starred)
       created_at: event.created_at,
       updated_at: event.created_at,
       state: 'open',
@@ -413,6 +422,7 @@ export const transformEventToItem = (event: GitHubEvent): GitHubItem | null => {
       event_id: event.id,
       html_url: `https://github.com/${repo.name}`,
       title: 'Made repository public',
+      action: 'publicized', // PublicEvent doesn't have payload.action, using semantic action
       created_at: event.created_at,
       updated_at: event.created_at,
       state: 'open',
@@ -447,6 +457,7 @@ export const transformEventToItem = (event: GitHubEvent): GitHubItem | null => {
       event_id: event.id,
       html_url: `https://github.com/${repo.name}`,
       title: title,
+      action: 'deleted', // DeleteEvent doesn't have payload.action, using semantic action
       created_at: event.created_at,
       updated_at: event.created_at,
       state: 'closed',
@@ -498,6 +509,7 @@ export const transformEventToItem = (event: GitHubEvent): GitHubItem | null => {
       event_id: event.id,
       html_url: page.html_url || `https://github.com/${repo.name}/wiki`,
       title: title,
+      action: action, // e.g., 'created', 'edited' (from the first wiki page)
       created_at: event.created_at,
       updated_at: event.created_at,
       state: 'open',

--- a/src/utils/summaryGrouping.ts
+++ b/src/utils/summaryGrouping.ts
@@ -261,7 +261,7 @@ export const categorizeItem = (
       // Issue was created in range - either explicitly opened or no action specified (from Search API)
       return SUMMARY_GROUP_NAMES.ISSUES_OPENED;
     } else if (updatedInRange) {
-      // Issue had activity (labeled, assigned, etc.) but wasn't opened/closed within timeframe
+      // Issue was updated in the timeframe (labeled, assigned, etc.) but was not categorized as opened/closed in this summary
       return SUMMARY_GROUP_NAMES.ISSUES_UPDATED;
     }
 

--- a/src/utils/summaryGrouping.ts
+++ b/src/utils/summaryGrouping.ts
@@ -69,8 +69,8 @@ export const getEventType = (item: GitHubItem): string => {
   if (item.title.startsWith('Comment on:')) {
     return 'comment';
   }
-  // Check if this is a push event (title starts with "Pushed")
-  if (item.title.startsWith('Pushed')) {
+  // Check if this is a push event (title starts with "Committed")
+  if (item.title.startsWith('Committed')) {
     return 'commit';
   }
   // Check for other event types that don't belong to issues/PRs
@@ -168,7 +168,8 @@ export const categorizeItemWithoutDateFiltering = (
 
     if (item.state === 'closed' && closedInRange) {
       return SUMMARY_GROUP_NAMES.ISSUES_CLOSED;
-    } else if (createdInRange) {
+    } else if (createdInRange && (!item.action || item.action === 'opened')) {
+      // Issue was created in range - either explicitly opened or no action specified (from Search API)
       return SUMMARY_GROUP_NAMES.ISSUES_OPENED;
     } else {
       return SUMMARY_GROUP_NAMES.ISSUES_UPDATED;
@@ -256,14 +257,14 @@ export const categorizeItem = (
     if (item.state === 'closed' && closedInRange) {
       // Issue was closed within the timeframe
       return SUMMARY_GROUP_NAMES.ISSUES_CLOSED;
-    } else if (createdInRange) {
-      // Issue was created within the timeframe (regardless of current state)
+    } else if (createdInRange && (!item.action || item.action === 'opened')) {
+      // Issue was created in range - either explicitly opened or no action specified (from Search API)
       return SUMMARY_GROUP_NAMES.ISSUES_OPENED;
-    } else if (updatedInRange && !createdInRange && !closedInRange) {
-      // Issue had activity but wasn't created/closed within timeframe
+    } else if (updatedInRange) {
+      // Issue had activity (labeled, assigned, etc.) but wasn't opened/closed within timeframe
       return SUMMARY_GROUP_NAMES.ISSUES_UPDATED;
     }
-    
+
     // If none of the above conditions are met, filter out the issue
     return null;
   }


### PR DESCRIPTION
This pull request introduces improvements to how action metadata (such as "opened", "closed", "labeled") and avatars are displayed for GitHub items, especially issues and pull requests. It also ensures that action metadata is shown as a separate badge rather than appended to item titles, and adds comprehensive tests to verify these behaviors.

**UI/UX Improvements:**

* Action metadata (`action` and `originalEventType`) is now displayed as labeled badges in both the `DescriptionDialog` and `ItemRow` components, enhancing clarity and consistency. [[1]](diffhunk://#diff-061343dfa372fb1bdc97b2539f8b9769841d8c6b47ff59e58016009d34e6c8fcR141-R170) [[2]](diffhunk://#diff-504ba6c9733749b57cb5e39951f23eee4d0100c3e4f08d273e0ed730c450bd48R195-R203) [[3]](diffhunk://#diff-504ba6c9733749b57cb5e39951f23eee4d0100c3e4f08d273e0ed730c450bd48R386-R394)
* For issues with a distinct assignee (different from the actor), both the actor's and assignee's avatars are shown in a stack, improving visual context. Pull requests continue to show only the actor's avatar. [[1]](diffhunk://#diff-504ba6c9733749b57cb5e39951f23eee4d0100c3e4f08d273e0ed730c450bd48R150-R171) [[2]](diffhunk://#diff-504ba6c9733749b57cb5e39951f23eee4d0100c3e4f08d273e0ed730c450bd48R343-R363)

**Type and Utility Updates:**

* The `GitHubItem` type now includes an optional `action` field to represent the event action for badge display.
* Refactored avatar and assignee display logic for clarity and maintainability.

**Testing Enhancements:**

* Added a comprehensive test suite for `ItemRow` covering avatar and action badge display under different scenarios.

**PR Enrichment and Title Handling:**

* Ensured that action metadata is no longer appended to item titles during enrichment; it is instead displayed as a badge, with tests verifying this behavior. [[1]](diffhunk://#diff-aea9681c2d6abca2c34b5b8ddd18f385a7e03e0b8efdab0e602168b7f5e266e6L187-R188) [[2]](diffhunk://#diff-aea9681c2d6abca2c34b5b8ddd18f385a7e03e0b8efdab0e602168b7f5e266e6R228-R314) [[3]](diffhunk://#diff-aea9681c2d6abca2c34b5b8ddd18f385a7e03e0b8efdab0e602168b7f5e266e6L442-R533) [[4]](diffhunk://#diff-aea9681c2d6abca2c34b5b8ddd18f385a7e03e0b8efdab0e602168b7f5e266e6L501-R594) [[5]](diffhunk://#diff-aea9681c2d6abca2c34b5b8ddd18f385a7e03e0b8efdab0e602168b7f5e266e6L548-R637)

**Minor Fixes:**

* Updated a test to reflect a more accurate push event title.