### PR TITLE
Show search syntax info on focus of search box

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -179,13 +179,21 @@ function App() {
     );
   }, [results]);
 
-  // Extract unique labels from results for search suggestions
+  // Extract labels from results sorted by frequency (most used first)
   const availableLabels = useMemo(() => {
-    const labels = new Set<string>();
+    const labelCounts = new Map<string, number>();
     results.forEach(item => {
-      item.labels?.forEach(label => labels.add(label.name));
+      item.labels?.forEach(label => {
+        labelCounts.set(label.name, (labelCounts.get(label.name) || 0) + 1);
+      });
     });
-    return Array.from(labels).sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+    // Sort by frequency (descending), then alphabetically for ties
+    return Array.from(labelCounts.entries())
+      .sort((a, b) => {
+        if (b[1] !== a[1]) return b[1] - a[1]; // Sort by count descending
+        return a[0].toLowerCase().localeCompare(b[0].toLowerCase()); // Then alphabetically
+      })
+      .map(([label]) => label);
   }, [results]);
 
   // Extract unique repos from results for search suggestions

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -163,6 +163,38 @@ function App() {
     return [];
   }, [cachedAvatarUrls]);
 
+  // Extract unique users from results for search suggestions
+  const availableUsers = useMemo(() => {
+    const users = new Set<string>();
+    results.forEach(item => {
+      if (item.user?.login) {
+        users.add(item.user.login);
+      }
+    });
+    return Array.from(users).sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+  }, [results]);
+
+  // Extract unique labels from results for search suggestions
+  const availableLabels = useMemo(() => {
+    const labels = new Set<string>();
+    results.forEach(item => {
+      item.labels?.forEach(label => labels.add(label.name));
+    });
+    return Array.from(labels).sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+  }, [results]);
+
+  // Extract unique repos from results for search suggestions
+  const availableRepos = useMemo(() => {
+    const repos = new Set<string>();
+    results.forEach(item => {
+      if (item.repository_url) {
+        const repoName = item.repository_url.replace('https://api.github.com/repos/', '');
+        repos.add(repoName);
+      }
+    });
+    return Array.from(repos).sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+  }, [results]);
+
   const handleManualSpin = useCallback(() => {
     setIsManuallySpinning(true);
     setTimeout(() => setIsManuallySpinning(false), 2000);
@@ -373,6 +405,9 @@ function App() {
             <HeaderSearch
               searchText={searchText}
               onSearchChange={setSearchText}
+              availableUsers={availableUsers}
+              availableLabels={availableLabels}
+              availableRepos={availableRepos}
             />
             
             {/* Mobile-optimized actions */}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -163,15 +163,20 @@ function App() {
     return [];
   }, [cachedAvatarUrls]);
 
-  // Extract unique users from results for search suggestions
+  // Extract unique users from results for search suggestions (with avatars)
   const availableUsers = useMemo(() => {
-    const users = new Set<string>();
+    const userMap = new Map<string, { login: string; avatar_url: string }>();
     results.forEach(item => {
-      if (item.user?.login) {
-        users.add(item.user.login);
+      if (item.user?.login && !userMap.has(item.user.login)) {
+        userMap.set(item.user.login, {
+          login: item.user.login,
+          avatar_url: item.user.avatar_url || '',
+        });
       }
     });
-    return Array.from(users).sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+    return Array.from(userMap.values()).sort((a, b) =>
+      a.login.toLowerCase().localeCompare(b.login.toLowerCase())
+    );
   }, [results]);
 
   // Extract unique labels from results for search suggestions

--- a/src/components/HeaderSearch.tsx
+++ b/src/components/HeaderSearch.tsx
@@ -1,9 +1,10 @@
-import React, { memo, useCallback, useState } from 'react';
+import React, { memo, useCallback, useState, useRef } from 'react';
 import {
   TextInput,
   Box,
   Text,
   Popover,
+  ActionList,
 } from '@primer/react';
 import { XIcon, SearchIcon } from '@primer/octicons-react';
 import { useDebouncedSearch } from '../hooks/useDebouncedSearch';
@@ -12,14 +13,24 @@ interface HeaderSearchProps {
   searchText: string;
   onSearchChange: (value: string) => void;
   placeholder?: string;
+  /** Available users for suggestions */
+  availableUsers?: string[];
+  /** Available labels for suggestions */
+  availableLabels?: string[];
+  /** Available repos for suggestions */
+  availableRepos?: string[];
 }
 
 const HeaderSearch = memo(function HeaderSearch({
   searchText,
   onSearchChange,
-  placeholder = 'Search'
+  placeholder = 'Search',
+  availableUsers = [],
+  availableLabels = [],
+  availableRepos = [],
 }: HeaderSearchProps) {
   const [isFocused, setIsFocused] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   // Use debounced search hook
   const { inputValue, setInputValue, clearSearch } = useDebouncedSearch(
@@ -43,11 +54,30 @@ const HeaderSearch = memo(function HeaderSearch({
     setIsFocused(true);
   }, []);
 
-  const handleBlur = useCallback(() => {
+  const handleBlur = useCallback((event: React.FocusEvent) => {
+    // Check if focus is moving to the popover content
+    const relatedTarget = event.relatedTarget as HTMLElement;
+    if (relatedTarget?.closest('[data-search-popover]')) {
+      // Keep popover open, refocus input
+      return;
+    }
     setIsFocused(false);
   }, []);
 
-  const showSyntaxHelp = !isFocused && !inputValue;
+  // Add filter text to search input
+  const addFilterText = useCallback((filterText: string) => {
+    const newValue = inputValue ? `${inputValue} ${filterText}` : filterText;
+    setInputValue(newValue);
+    // Keep focus on input
+    inputRef.current?.focus();
+  }, [inputValue, setInputValue]);
+
+  const showSyntaxHelp = isFocused;
+
+  // Get top suggestions (limit to prevent huge lists)
+  const topUsers = availableUsers.slice(0, 5);
+  const topLabels = availableLabels.slice(0, 8);
+  const topRepos = availableRepos.slice(0, 5);
 
   return (
     <Box
@@ -62,6 +92,7 @@ const HeaderSearch = memo(function HeaderSearch({
       }}
     >
       <TextInput
+        ref={inputRef}
         value={inputValue}
         onChange={handleInputChange}
         onFocus={handleFocus}
@@ -92,14 +123,85 @@ const HeaderSearch = memo(function HeaderSearch({
       />
       {showSyntaxHelp && (
         <Popover open={true} caret="top">
-          <Popover.Content sx={{ p: 2, mt: 1, fontSize: '12px' }}>
-            <Text sx={{ fontWeight: 'bold', display: 'block', mb: 1 }}>Search syntax:</Text>
-            <Box as="ul" sx={{ m: 0, pl: 3 }}>
+          <Popover.Content
+            data-search-popover
+            sx={{
+              p: 2,
+              mt: 1,
+              fontSize: '12px',
+              maxHeight: '400px',
+              overflowY: 'auto',
+              minWidth: '280px',
+            }}
+          >
+            <Text sx={{ fontWeight: 'bold', display: 'block', mb: 1, color: 'fg.default' }}>
+              Search syntax:
+            </Text>
+            <Box as="ul" sx={{ m: 0, pl: 3, mb: 2, color: 'fg.muted' }}>
               <li><code>label:name</code> - include label</li>
               <li><code>-label:name</code> - exclude label</li>
               <li><code>user:name</code> - filter by author</li>
-              <li><code>repo:owner/repo</code> - filter by repo</li>
+              <li><code>repo:org/repo</code> - filter by repo</li>
+              <li><code>-repo:org/repo</code> - exclude repo</li>
+              <li><em>free text</em> - search in title/body</li>
             </Box>
+
+            {topUsers.length > 0 && (
+              <>
+                <Text sx={{ fontWeight: 'bold', display: 'block', mb: 1, mt: 2, color: 'fg.default' }}>
+                  Filter by user:
+                </Text>
+                <ActionList sx={{ py: 0 }}>
+                  {topUsers.map(user => (
+                    <ActionList.Item
+                      key={user}
+                      onSelect={() => addFilterText(`user:${user}`)}
+                      sx={{ fontSize: '12px', py: 1 }}
+                    >
+                      user:{user}
+                    </ActionList.Item>
+                  ))}
+                </ActionList>
+              </>
+            )}
+
+            {topLabels.length > 0 && (
+              <>
+                <Text sx={{ fontWeight: 'bold', display: 'block', mb: 1, mt: 2, color: 'fg.default' }}>
+                  Filter by label:
+                </Text>
+                <ActionList sx={{ py: 0 }}>
+                  {topLabels.map(label => (
+                    <ActionList.Item
+                      key={label}
+                      onSelect={() => addFilterText(`label:${label}`)}
+                      sx={{ fontSize: '12px', py: 1 }}
+                    >
+                      label:{label}
+                    </ActionList.Item>
+                  ))}
+                </ActionList>
+              </>
+            )}
+
+            {topRepos.length > 0 && (
+              <>
+                <Text sx={{ fontWeight: 'bold', display: 'block', mb: 1, mt: 2, color: 'fg.default' }}>
+                  Filter by repo:
+                </Text>
+                <ActionList sx={{ py: 0 }}>
+                  {topRepos.map(repo => (
+                    <ActionList.Item
+                      key={repo}
+                      onSelect={() => addFilterText(`repo:${repo}`)}
+                      sx={{ fontSize: '12px', py: 1 }}
+                    >
+                      repo:{repo}
+                    </ActionList.Item>
+                  ))}
+                </ActionList>
+              </>
+            )}
           </Popover.Content>
         </Popover>
       )}
@@ -107,4 +209,4 @@ const HeaderSearch = memo(function HeaderSearch({
   );
 });
 
-export default HeaderSearch; 
+export default HeaderSearch;

--- a/src/components/HeaderSearch.tsx
+++ b/src/components/HeaderSearch.tsx
@@ -44,12 +44,23 @@ const avatarButtonStyles: SxProp['sx'] = {
   },
 };
 
-const tokenStyles: SxProp['sx'] = {
+const pillButtonStyles: SxProp['sx'] = {
   cursor: 'pointer',
-  fontSize: '11px',
-  transition: 'transform 0.1s ease',
+  fontSize: '10px',
+  fontWeight: 500,
+  border: '1px solid',
+  borderColor: 'border.default',
+  borderRadius: '2em',
+  px: '6px',
+  py: '1px',
+  background: 'canvas.subtle',
+  color: 'fg.muted',
+  whiteSpace: 'nowrap',
+  transition: 'all 0.1s ease',
   ':hover': {
-    transform: 'scale(1.05)',
+    background: 'canvas.default',
+    borderColor: 'accent.emphasis',
+    color: 'fg.default',
   },
 };
 
@@ -269,24 +280,15 @@ const HeaderSearch = memo(function HeaderSearch({
 
             {/* Labels Section */}
             {hasLabels && (
-              <Box sx={{ mb: 3 }}>
+              <Box sx={{ mb: 2 }}>
                 <SectionHeader>Filter by Label</SectionHeader>
-                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: '4px' }}>
                   {topLabels.map(label => (
                     <Box
                       key={label}
                       as="button"
                       onMouseDown={createLabelMouseDownHandler(label)}
-                      sx={{
-                        ...tokenStyles,
-                        border: '1px solid',
-                        borderColor: 'border.default',
-                        borderRadius: '2em',
-                        px: 2,
-                        py: '2px',
-                        background: 'canvas.subtle',
-                        color: 'fg.default',
-                      }}
+                      sx={pillButtonStyles}
                     >
                       {label}
                     </Box>
@@ -299,22 +301,13 @@ const HeaderSearch = memo(function HeaderSearch({
             {hasRepos && (
               <Box>
                 <SectionHeader>Filter by Repository</SectionHeader>
-                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: '4px' }}>
                   {topRepos.map(repo => (
                     <Box
                       key={repo}
                       as="button"
                       onMouseDown={createRepoMouseDownHandler(repo)}
-                      sx={{
-                        ...tokenStyles,
-                        border: '1px solid',
-                        borderColor: 'border.default',
-                        borderRadius: '2em',
-                        px: 2,
-                        py: '2px',
-                        background: 'canvas.subtle',
-                        color: 'fg.default',
-                      }}
+                      sx={pillButtonStyles}
                     >
                       {repo}
                     </Box>

--- a/src/components/HeaderSearch.tsx
+++ b/src/components/HeaderSearch.tsx
@@ -1,7 +1,8 @@
-import React, { memo, useCallback } from 'react';
+import React, { memo, useCallback, useState } from 'react';
 import {
   TextInput,
   Box,
+  Text,
 } from '@primer/react';
 import { XIcon, SearchIcon } from '@primer/octicons-react';
 import { useDebouncedSearch } from '../hooks/useDebouncedSearch';
@@ -17,6 +18,7 @@ const HeaderSearch = memo(function HeaderSearch({
   onSearchChange,
   placeholder = 'Search'
 }: HeaderSearchProps) {
+  const [isFocused, setIsFocused] = useState(false);
 
   // Use debounced search hook
   const { inputValue, setInputValue, clearSearch } = useDebouncedSearch(
@@ -35,6 +37,15 @@ const HeaderSearch = memo(function HeaderSearch({
     clearSearch();
   }, [clearSearch]);
 
+  // Handle focus state
+  const handleFocus = useCallback(() => {
+    setIsFocused(true);
+  }, []);
+
+  const handleBlur = useCallback(() => {
+    setIsFocused(false);
+  }, []);
+
   return (
     <Box
       sx={{
@@ -49,6 +60,8 @@ const HeaderSearch = memo(function HeaderSearch({
       <TextInput
         value={inputValue}
         onChange={handleInputChange}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
         placeholder={placeholder}
         size="small"
         leadingVisual={SearchIcon}
@@ -73,6 +86,18 @@ const HeaderSearch = memo(function HeaderSearch({
         }}
         block={true}
       />
+      {!isFocused && !inputValue && (
+        <Text
+          sx={{
+            fontSize: '11px',
+            color: 'fg.muted',
+            mt: 1,
+            display: 'block',
+          }}
+        >
+          Syntax: label:name, -label:name, user:name, repo:owner/repo
+        </Text>
+      )}
     </Box>
   );
 });

--- a/src/components/HeaderSearch.tsx
+++ b/src/components/HeaderSearch.tsx
@@ -4,17 +4,24 @@ import {
   Box,
   Text,
   Popover,
-  ActionList,
+  Avatar,
+  Token,
+  Tooltip,
 } from '@primer/react';
 import { XIcon, SearchIcon } from '@primer/octicons-react';
 import { useDebouncedSearch } from '../hooks/useDebouncedSearch';
+
+interface UserSuggestion {
+  login: string;
+  avatar_url: string;
+}
 
 interface HeaderSearchProps {
   searchText: string;
   onSearchChange: (value: string) => void;
   placeholder?: string;
   /** Available users for suggestions */
-  availableUsers?: string[];
+  availableUsers?: UserSuggestion[];
   /** Available labels for suggestions */
   availableLabels?: string[];
   /** Available repos for suggestions */
@@ -75,8 +82,8 @@ const HeaderSearch = memo(function HeaderSearch({
   const showSyntaxHelp = isFocused;
 
   // Get top suggestions (limit to prevent huge lists)
-  const topUsers = availableUsers.slice(0, 5);
-  const topLabels = availableLabels.slice(0, 8);
+  const topUsers = availableUsers.slice(0, 8);
+  const topLabels = availableLabels.slice(0, 10);
   const topRepos = availableRepos.slice(0, 5);
 
   return (
@@ -126,81 +133,196 @@ const HeaderSearch = memo(function HeaderSearch({
           <Popover.Content
             data-search-popover
             sx={{
-              p: 2,
+              p: 3,
               mt: 1,
               fontSize: '12px',
-              maxHeight: '400px',
+              maxHeight: '450px',
               overflowY: 'auto',
-              minWidth: '280px',
+              minWidth: '320px',
+              boxShadow: 'shadow.large',
             }}
           >
-            <Text sx={{ fontWeight: 'bold', display: 'block', mb: 1, color: 'fg.default' }}>
-              Search syntax:
-            </Text>
-            <Box as="ul" sx={{ m: 0, pl: 3, mb: 2, color: 'fg.muted' }}>
-              <li><code>label:name</code> - include label</li>
-              <li><code>-label:name</code> - exclude label</li>
-              <li><code>user:name</code> - filter by author</li>
-              <li><code>repo:org/repo</code> - filter by repo</li>
-              <li><code>-repo:org/repo</code> - exclude repo</li>
-              <li><em>free text</em> - search in title/body</li>
+            {/* Search Syntax Section */}
+            <Box sx={{ mb: 3 }}>
+              <Text
+                sx={{
+                  fontSize: '11px',
+                  fontWeight: 'semibold',
+                  color: 'fg.muted',
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.5px',
+                  display: 'block',
+                  mb: 2,
+                }}
+              >
+                Search Syntax
+              </Text>
+              <Box
+                sx={{
+                  display: 'grid',
+                  gridTemplateColumns: '1fr 1fr',
+                  gap: 1,
+                  fontSize: '11px',
+                  color: 'fg.muted',
+                }}
+              >
+                <Text><code>label:name</code></Text>
+                <Text><code>-label:name</code></Text>
+                <Text><code>user:name</code></Text>
+                <Text><code>repo:org/repo</code></Text>
+              </Box>
             </Box>
 
+            {/* Users Section - Avatars */}
             {topUsers.length > 0 && (
-              <>
-                <Text sx={{ fontWeight: 'bold', display: 'block', mb: 1, mt: 2, color: 'fg.default' }}>
-                  Filter by user:
+              <Box sx={{ mb: 3 }}>
+                <Text
+                  sx={{
+                    fontSize: '11px',
+                    fontWeight: 'semibold',
+                    color: 'fg.muted',
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.5px',
+                    display: 'block',
+                    mb: 2,
+                  }}
+                >
+                  Filter by User
                 </Text>
-                <ActionList sx={{ py: 0 }}>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    gap: 2,
+                  }}
+                >
                   {topUsers.map(user => (
-                    <ActionList.Item
-                      key={user}
-                      onSelect={() => addFilterText(`user:${user}`)}
-                      sx={{ fontSize: '12px', py: 1 }}
-                    >
-                      user:{user}
-                    </ActionList.Item>
+                    <Tooltip key={user.login} text={`user:${user.login}`} direction="s">
+                      <Box
+                        as="button"
+                        onClick={() => addFilterText(`user:${user.login}`)}
+                        sx={{
+                          border: 'none',
+                          background: 'none',
+                          padding: 0,
+                          cursor: 'pointer',
+                          borderRadius: '50%',
+                          transition: 'transform 0.15s ease, box-shadow 0.15s ease',
+                          ':hover': {
+                            transform: 'scale(1.15)',
+                            boxShadow: '0 0 0 2px var(--bgColor-accent-emphasis, #0969da)',
+                          },
+                          ':focus': {
+                            outline: 'none',
+                            boxShadow: '0 0 0 2px var(--bgColor-accent-emphasis, #0969da)',
+                          },
+                        }}
+                      >
+                        <Avatar src={user.avatar_url} size={32} alt={user.login} />
+                      </Box>
+                    </Tooltip>
                   ))}
-                </ActionList>
-              </>
+                </Box>
+              </Box>
             )}
 
+            {/* Labels Section - Pills */}
             {topLabels.length > 0 && (
-              <>
-                <Text sx={{ fontWeight: 'bold', display: 'block', mb: 1, mt: 2, color: 'fg.default' }}>
-                  Filter by label:
+              <Box sx={{ mb: 3 }}>
+                <Text
+                  sx={{
+                    fontSize: '11px',
+                    fontWeight: 'semibold',
+                    color: 'fg.muted',
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.5px',
+                    display: 'block',
+                    mb: 2,
+                  }}
+                >
+                  Filter by Label
                 </Text>
-                <ActionList sx={{ py: 0 }}>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    gap: 1,
+                  }}
+                >
                   {topLabels.map(label => (
-                    <ActionList.Item
+                    <Token
                       key={label}
-                      onSelect={() => addFilterText(`label:${label}`)}
-                      sx={{ fontSize: '12px', py: 1 }}
-                    >
-                      label:{label}
-                    </ActionList.Item>
+                      text={label}
+                      onClick={() => addFilterText(`label:${label}`)}
+                      sx={{
+                        cursor: 'pointer',
+                        fontSize: '11px',
+                        transition: 'transform 0.1s ease',
+                        ':hover': {
+                          transform: 'scale(1.05)',
+                        },
+                      }}
+                    />
                   ))}
-                </ActionList>
-              </>
+                </Box>
+              </Box>
             )}
 
+            {/* Repos Section */}
             {topRepos.length > 0 && (
-              <>
-                <Text sx={{ fontWeight: 'bold', display: 'block', mb: 1, mt: 2, color: 'fg.default' }}>
-                  Filter by repo:
+              <Box>
+                <Text
+                  sx={{
+                    fontSize: '11px',
+                    fontWeight: 'semibold',
+                    color: 'fg.muted',
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.5px',
+                    display: 'block',
+                    mb: 2,
+                  }}
+                >
+                  Filter by Repository
                 </Text>
-                <ActionList sx={{ py: 0 }}>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 1,
+                  }}
+                >
                   {topRepos.map(repo => (
-                    <ActionList.Item
+                    <Box
                       key={repo}
-                      onSelect={() => addFilterText(`repo:${repo}`)}
-                      sx={{ fontSize: '12px', py: 1 }}
+                      as="button"
+                      onClick={() => addFilterText(`repo:${repo}`)}
+                      sx={{
+                        border: '1px solid',
+                        borderColor: 'border.default',
+                        background: 'canvas.subtle',
+                        borderRadius: 2,
+                        px: 2,
+                        py: 1,
+                        fontSize: '11px',
+                        color: 'fg.default',
+                        cursor: 'pointer',
+                        textAlign: 'left',
+                        transition: 'background 0.1s ease, border-color 0.1s ease',
+                        ':hover': {
+                          background: 'canvas.default',
+                          borderColor: 'border.muted',
+                        },
+                        ':focus': {
+                          outline: 'none',
+                          boxShadow: '0 0 0 2px var(--bgColor-accent-emphasis, #0969da)',
+                        },
+                      }}
                     >
-                      repo:{repo}
-                    </ActionList.Item>
+                      {repo}
+                    </Box>
                   ))}
-                </ActionList>
-              </>
+                </Box>
+              </Box>
             )}
           </Popover.Content>
         </Popover>

--- a/src/components/HeaderSearch.tsx
+++ b/src/components/HeaderSearch.tsx
@@ -3,6 +3,7 @@ import {
   TextInput,
   Box,
   Text,
+  Popover,
 } from '@primer/react';
 import { XIcon, SearchIcon } from '@primer/octicons-react';
 import { useDebouncedSearch } from '../hooks/useDebouncedSearch';
@@ -46,11 +47,14 @@ const HeaderSearch = memo(function HeaderSearch({
     setIsFocused(false);
   }, []);
 
+  const showSyntaxHelp = !isFocused && !inputValue;
+
   return (
     <Box
       sx={{
         minWidth: '300px',
         maxWidth: '500px',
+        position: 'relative',
         '@media (max-width: 767px)': {
           minWidth: '200px',
           maxWidth: '280px',
@@ -86,17 +90,18 @@ const HeaderSearch = memo(function HeaderSearch({
         }}
         block={true}
       />
-      {!isFocused && !inputValue && (
-        <Text
-          sx={{
-            fontSize: '11px',
-            color: 'fg.muted',
-            mt: 1,
-            display: 'block',
-          }}
-        >
-          Syntax: label:name, -label:name, user:name, repo:owner/repo
-        </Text>
+      {showSyntaxHelp && (
+        <Popover open={true} caret="top">
+          <Popover.Content sx={{ p: 2, mt: 1, fontSize: '12px' }}>
+            <Text sx={{ fontWeight: 'bold', display: 'block', mb: 1 }}>Search syntax:</Text>
+            <Box as="ul" sx={{ m: 0, pl: 3 }}>
+              <li><code>label:name</code> - include label</li>
+              <li><code>-label:name</code> - exclude label</li>
+              <li><code>user:name</code> - filter by author</li>
+              <li><code>repo:owner/repo</code> - filter by repo</li>
+            </Box>
+          </Popover.Content>
+        </Popover>
       )}
     </Box>
   );

--- a/src/components/HeaderSearch.tsx
+++ b/src/components/HeaderSearch.tsx
@@ -5,7 +5,6 @@ import {
   Text,
   Popover,
   Avatar,
-  Token,
   Tooltip,
   type SxProp,
 } from '@primer/react';
@@ -134,26 +133,36 @@ const HeaderSearch = memo(function HeaderSearch({
 
   const addFilterText = useCallback(
     (filterText: string) => {
-      setInputValue(buildFilterText(inputValue, filterText));
-      // Separate side effect using requestAnimationFrame for proper timing
-      requestAnimationFrame(() => inputRef.current?.focus());
+      const newValue = buildFilterText(inputValue, filterText);
+      setInputValue(newValue);
+      // Close popover after selection
+      setIsFocused(false);
     },
     [inputValue, setInputValue]
   );
 
-  // Factory functions for click handlers to avoid inline closures in render
-  const createUserClickHandler = useCallback(
-    (login: string) => () => addFilterText(`user:${login}`),
+  // Factory functions for mousedown handlers (mousedown fires before blur)
+  const createUserMouseDownHandler = useCallback(
+    (login: string) => (e: React.MouseEvent) => {
+      e.preventDefault(); // Prevent blur
+      addFilterText(`user:${login}`);
+    },
     [addFilterText]
   );
 
-  const createLabelClickHandler = useCallback(
-    (label: string) => () => addFilterText(`label:${label}`),
+  const createLabelMouseDownHandler = useCallback(
+    (label: string) => (e: React.MouseEvent) => {
+      e.preventDefault(); // Prevent blur
+      addFilterText(`label:${label}`);
+    },
     [addFilterText]
   );
 
-  const createRepoClickHandler = useCallback(
-    (repo: string) => () => addFilterText(`repo:${repo}`),
+  const createRepoMouseDownHandler = useCallback(
+    (repo: string) => (e: React.MouseEvent) => {
+      e.preventDefault(); // Prevent blur
+      addFilterText(`repo:${repo}`);
+    },
     [addFilterText]
   );
 
@@ -247,7 +256,7 @@ const HeaderSearch = memo(function HeaderSearch({
                     <Tooltip key={user.login} text={`user:${user.login}`} direction="s">
                       <Box
                         as="button"
-                        onClick={createUserClickHandler(user.login)}
+                        onMouseDown={createUserMouseDownHandler(user.login)}
                         sx={avatarButtonStyles}
                       >
                         <Avatar src={user.avatar_url} size={32} alt={user.login} />
@@ -264,12 +273,23 @@ const HeaderSearch = memo(function HeaderSearch({
                 <SectionHeader>Filter by Label</SectionHeader>
                 <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
                   {topLabels.map(label => (
-                    <Token
+                    <Box
                       key={label}
-                      text={label}
-                      onClick={createLabelClickHandler(label)}
-                      sx={tokenStyles}
-                    />
+                      as="button"
+                      onMouseDown={createLabelMouseDownHandler(label)}
+                      sx={{
+                        ...tokenStyles,
+                        border: '1px solid',
+                        borderColor: 'border.default',
+                        borderRadius: '2em',
+                        px: 2,
+                        py: '2px',
+                        background: 'canvas.subtle',
+                        color: 'fg.default',
+                      }}
+                    >
+                      {label}
+                    </Box>
                   ))}
                 </Box>
               </Box>
@@ -281,12 +301,23 @@ const HeaderSearch = memo(function HeaderSearch({
                 <SectionHeader>Filter by Repository</SectionHeader>
                 <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
                   {topRepos.map(repo => (
-                    <Token
+                    <Box
                       key={repo}
-                      text={repo}
-                      onClick={createRepoClickHandler(repo)}
-                      sx={tokenStyles}
-                    />
+                      as="button"
+                      onMouseDown={createRepoMouseDownHandler(repo)}
+                      sx={{
+                        ...tokenStyles,
+                        border: '1px solid',
+                        borderColor: 'border.default',
+                        borderRadius: '2em',
+                        px: 2,
+                        py: '2px',
+                        background: 'canvas.subtle',
+                        color: 'fg.default',
+                      }}
+                    >
+                      {repo}
+                    </Box>
                   ))}
                 </Box>
               </Box>

--- a/src/components/HeaderSearch.tsx
+++ b/src/components/HeaderSearch.tsx
@@ -83,8 +83,8 @@ const HeaderSearch = memo(function HeaderSearch({
 
   // Get top suggestions (limit to prevent huge lists)
   const topUsers = availableUsers.slice(0, 8);
-  const topLabels = availableLabels.slice(0, 10);
-  const topRepos = availableRepos.slice(0, 5);
+  const topLabels = availableLabels.slice(0, 12);
+  const topRepos = availableRepos.slice(0, 8);
 
   return (
     <Box
@@ -268,7 +268,7 @@ const HeaderSearch = memo(function HeaderSearch({
               </Box>
             )}
 
-            {/* Repos Section */}
+            {/* Repos Section - Pills */}
             {topRepos.length > 0 && (
               <Box>
                 <Text
@@ -287,39 +287,24 @@ const HeaderSearch = memo(function HeaderSearch({
                 <Box
                   sx={{
                     display: 'flex',
-                    flexDirection: 'column',
+                    flexWrap: 'wrap',
                     gap: 1,
                   }}
                 >
                   {topRepos.map(repo => (
-                    <Box
+                    <Token
                       key={repo}
-                      as="button"
+                      text={repo}
                       onClick={() => addFilterText(`repo:${repo}`)}
                       sx={{
-                        border: '1px solid',
-                        borderColor: 'border.default',
-                        background: 'canvas.subtle',
-                        borderRadius: 2,
-                        px: 2,
-                        py: 1,
-                        fontSize: '11px',
-                        color: 'fg.default',
                         cursor: 'pointer',
-                        textAlign: 'left',
-                        transition: 'background 0.1s ease, border-color 0.1s ease',
+                        fontSize: '11px',
+                        transition: 'transform 0.1s ease',
                         ':hover': {
-                          background: 'canvas.default',
-                          borderColor: 'border.muted',
-                        },
-                        ':focus': {
-                          outline: 'none',
-                          boxShadow: '0 0 0 2px var(--bgColor-accent-emphasis, #0969da)',
+                          transform: 'scale(1.05)',
                         },
                       }}
-                    >
-                      {repo}
-                    </Box>
+                    />
                   ))}
                 </Box>
               </Box>


### PR DESCRIPTION
This pull request adds a contextual search suggestion popover to the header search bar, making it easier for users to filter by user, label, or repository. It introduces logic to extract and sort suggestions from current search results and updates the UI to display these suggestions in a user-friendly popover with clickable filters and search syntax help.

**Enhancements to search suggestions and filtering:**

* Added logic in `App.tsx` to extract unique users (with avatars), most-used labels, and unique repositories from search results, sorting them appropriately for use as suggestions.
* Passed the newly computed `availableUsers`, `availableLabels`, and `availableRepos` as props to the `HeaderSearch` component.

**UI/UX improvements to the search bar:**

* Refactored `HeaderSearch.tsx` to display a popover with search syntax help and clickable suggestions for users, labels, and repositories when the search input is focused. The popover uses Primer components for styling and accessibility.
* Added reusable styles, section headers, and pure functions to keep the code DRY and maintainable; limited the number of suggestions shown for each category.
* Enabled keyboard focus management and improved event handling for popover interactions in the search component.