### PR TITLE
Add PR details to copy content function

### DIFF
--- a/src/utils/clipboard.test.ts
+++ b/src/utils/clipboard.test.ts
@@ -142,6 +142,11 @@ describe('generatePlainTextFormat', () => {
     expect(result).toContain('Status: closed (merged)');
     expect(result).toContain('Link: https://github.com/user/repo/issues/1');
 
+    // Should contain author information
+    expect(result).toContain('Author: testuser (https://github.com/testuser)');
+    expect(result).toContain('Author: developer (https://github.com/developer)');
+    expect(result).toContain('Author: docwriter (https://github.com/docwriter)');
+
     // Should contain labels for items that have them
     expect(result).toContain('Labels: bug, priority-high');
     expect(result).toContain('Labels: feature');
@@ -207,6 +212,14 @@ describe('generateHtmlFormat', () => {
     expect(result).toContain(
       '2. <a href="https://github.com/user/repo/pull/2"'
     );
+
+    // Should contain author information with links
+    expect(result).toContain('Author: <a href="https://github.com/testuser"');
+    expect(result).toContain('>testuser</a>');
+    expect(result).toContain('Author: <a href="https://github.com/developer"');
+    expect(result).toContain('>developer</a>');
+    expect(result).toContain('Author: <a href="https://github.com/docwriter"');
+    expect(result).toContain('>docwriter</a>');
 
     // Should contain type information
     expect(result).toContain('Type: Issue');

--- a/src/utils/clipboard.ts
+++ b/src/utils/clipboard.ts
@@ -139,6 +139,7 @@ export const generatePlainTextFormat = (
         group.items.forEach((item, index) => {
           plainText += `${index + 1}. ${item.title}\n`;
           plainText += `   Link: ${item.html_url}\n`;
+          plainText += `   Author: ${item.user.login} (${item.user.html_url})\n`;
           plainText += `   Type: ${item.pull_request ? 'Pull Request' : 'Issue'}${item.pull_request && (item.draft || item.pull_request.draft) ? ' (DRAFT)' : ''}\n`;
           plainText += `   Status: ${item.state}${item.merged ? ' (merged)' : ''}\n`;
           plainText += `   Created: ${formatDateForClipboard(item.created_at)}\n`;
@@ -180,6 +181,7 @@ export const generatePlainTextFormat = (
   items.forEach((item, index) => {
     plainText += `${index + 1}. ${item.title}\n`;
     plainText += `   Link: ${item.html_url}\n`;
+    plainText += `   Author: ${item.user.login} (${item.user.html_url})\n`;
     plainText += `   Type: ${item.pull_request ? 'Pull Request' : 'Issue'}${item.pull_request && (item.draft || item.pull_request.draft) ? ' (DRAFT)' : ''}\n`;
     plainText += `   Status: ${item.state}${item.merged ? ' (merged)' : ''}\n`;
     plainText += `   Created: ${formatDateForClipboard(item.created_at)}\n`;
@@ -279,6 +281,7 @@ export const generateHtmlFormat = (
     htmlContent += `    ${index + 1}. <a href="${item.html_url}" style="color: #0969da; text-decoration: none;">${item.title}</a>\n`;
     htmlContent += `  </div>\n`;
     htmlContent += `  <div style="color: #57606a; font-size: 14px; margin-left: 24px;">\n`;
+    htmlContent += `    <div>Author: <a href="${item.user.html_url}" style="color: #0969da; text-decoration: none;">${item.user.login}</a></div>\n`;
     htmlContent += `    <div>Type: ${item.pull_request ? 'Pull Request' : 'Issue'}${item.pull_request && (item.draft || item.pull_request.draft) ? ' <span style="color: #9a6700; font-weight: bold;">(DRAFT)</span>' : ''}</div>\n`;
     htmlContent += `    <div>Status: <span style="color: ${
       item.merged ? '#8250df' : item.state === 'closed' ? '#cf222e' : '#1a7f37'


### PR DESCRIPTION
When using "Copy content" (detailed format), include the author/implementer information for each PR/issue. Shows author username with link to their GitHub profile in both plain text and HTML formats.