### PR TITLE
Fetch all GitHub issues with pagination

### DIFF
--- a/src/hooks/useGitHubDataFetching.ts
+++ b/src/hooks/useGitHubDataFetching.ts
@@ -127,9 +127,10 @@ export const useGitHubDataFetching = ({
     return allEvents;
   };
 
-  // Fetch all search items (issues/PRs) for a username with pagination
+  // Fetch all search items (issues/PRs) for multiple usernames with pagination
+  // Combines users with OR in a single query to reduce API calls
   const fetchAllSearchItems = async (
-    username: string,
+    usernames: string[],
     token: string,
     startDate: string,
     endDate: string,
@@ -139,20 +140,24 @@ export const useGitHubDataFetching = ({
     const seenIds = new Set<number>();
     const perPage = GITHUB_API_PER_PAGE;
 
-    // Use "involves:" to match author, assignee, commenter, and mentions in one query
+    // Build query with multiple involves: joined by OR
+    // Format: "is:issue updated:... involves:user1 OR involves:user2 OR involves:user3"
+    const involvesClause = usernames.map(u => `involves:${u}`).join(' OR ');
+
     const queries = [
-      { type: 'issue', query: `is:issue updated:${startDate}..${endDate} involves:${username}` },
-      { type: 'pull-request', query: `is:pull-request updated:${startDate}..${endDate} involves:${username}` },
+      { type: 'issue', query: `is:issue updated:${startDate}..${endDate} ${involvesClause}` },
+      { type: 'pull-request', query: `is:pull-request updated:${startDate}..${endDate} ${involvesClause}` },
     ];
 
     for (const { type, query: searchQuery } of queries) {
       let page = 1;
       let itemsFetchedForQuery = 0;
+      const usersLabel = usernames.length === 1 ? usernames[0] : `${usernames.length} users`;
 
       while (page <= GITHUB_SEARCH_API_MAX_PAGES) {
         try {
           const typeLabel = type === 'pull-request' ? 'PRs' : 'issues';
-          onProgress(`Fetching ${typeLabel} page ${page} for ${username}...`);
+          onProgress(`Fetching ${typeLabel} page ${page} for ${usersLabel}...`);
 
           const response = await fetch(
             `https://api.github.com/search/issues?q=${encodeURIComponent(searchQuery)}&per_page=${perPage}&page=${page}&sort=updated`,
@@ -169,7 +174,7 @@ export const useGitHubDataFetching = ({
 
             // Handle pagination limit error (422) - continue with next query
             if (response.status === 422 && responseJSON.message?.includes('pagination')) {
-              console.warn(`GitHub Search API pagination limit reached for ${username} ${type} at page ${page}.`);
+              console.warn(`GitHub Search API pagination limit reached for ${type} at page ${page}.`);
               break;
             }
 
@@ -203,7 +208,7 @@ export const useGitHubDataFetching = ({
           await new Promise(resolve => setTimeout(resolve, GITHUB_API_DELAY_MS));
 
         } catch (error) {
-          console.error(`Error fetching ${type} page ${page} for ${username}:`, error);
+          console.error(`Error fetching ${type} page ${page}:`, error);
           // Return partial results if we have any, otherwise throw
           if (allItems.length > 0) {
             console.warn(`Returning ${allItems.length} items collected before error`);
@@ -291,28 +296,32 @@ export const useGitHubDataFetching = ({
 
       // Accumulate all data from all users
       const allEvents: GitHubEvent[] = [];
-      const allSearchItems: GitHubItem[] = [];
 
-      // Fetch data for each username
+      // Fetch all issues/PRs for all users in a single combined query (2 API calls total)
+      // Query format: "is:issue updated:... involves:user1 OR involves:user2 OR involves:user3"
+      setCurrentUsername(usernames.length === 1 ? usernames[0] : `${usernames.length} users`);
+      let allSearchItems: GitHubItem[] = [];
+      try {
+        allSearchItems = await fetchAllSearchItems(usernames, githubToken, startDate, endDate, onProgress);
+        onProgress(`Fetched ${allSearchItems.length} issues/PRs for ${usernames.length} user(s)`);
+      } catch (error) {
+        console.error('Error fetching issues/PRs:', error);
+        onError(`Error fetching issues/PRs: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      }
+
+      // Fetch events for each username (Events API doesn't support combined queries)
       for (const singleUsername of usernames) {
         setCurrentUsername(singleUsername);
 
         try {
-          // Fetch issues/PRs (2 API calls per user using involves:)
-          const userSearchItems = await fetchAllSearchItems(singleUsername, githubToken, startDate, endDate, onProgress);
-          allSearchItems.push(...userSearchItems);
-          onProgress(`Fetched ${userSearchItems.length} issues/PRs for ${singleUsername}`);
-
-          // Fetch events
           const userEvents = await fetchAllEvents(singleUsername, githubToken, startDate, endDate, onProgress);
           allEvents.push(...userEvents);
           onProgress(`Fetched ${userEvents.length} events for ${singleUsername}`);
         } catch (error) {
-          console.error(`Error fetching data for ${singleUsername}:`, error);
+          console.error(`Error fetching events for ${singleUsername}:`, error);
           onError(
-            `Error fetching data for ${singleUsername}: ${error instanceof Error ? error.message : 'Unknown error'}`
+            `Error fetching events for ${singleUsername}: ${error instanceof Error ? error.message : 'Unknown error'}`
           );
-          // Continue with other usernames instead of breaking
           continue;
         }
       }

--- a/src/hooks/useGitHubDataFetching.ts
+++ b/src/hooks/useGitHubDataFetching.ts
@@ -127,9 +127,10 @@ export const useGitHubDataFetching = ({
     return allEvents;
   };
 
-  // Fetch all search items (issues/PRs) for a username with pagination
-  const fetchAllSearchItems = async (
-    username: string,
+  // Fetch all search items (issues/PRs) for multiple usernames with pagination
+  // Combines users into single queries to reduce API calls
+  const fetchAllSearchItemsForUsers = async (
+    usernames: string[],
     token: string,
     startDate: string,
     endDate: string,
@@ -139,11 +140,21 @@ export const useGitHubDataFetching = ({
     const seenIds = new Set<number>();
     const perPage = GITHUB_API_PER_PAGE;
 
-    // GitHub Apps with user access tokens require separate queries for issues and PRs
-    // Use "involves:" to match author, assignee, commenter, and mentions in one query
+    // Build combined query for all users using OR
+    // Format: "is:issue updated:... involves:user1 OR is:issue updated:... involves:user2"
+    // This works because AND has higher precedence than OR in GitHub search
+    const buildCombinedQuery = (type: string) => {
+      const typeFilter = type === 'issue' ? 'is:issue' : 'is:pull-request';
+      const dateFilter = `updated:${startDate}..${endDate}`;
+
+      return usernames
+        .map(user => `${typeFilter} ${dateFilter} involves:${user}`)
+        .join(' OR ');
+    };
+
     const queries = [
-      { type: 'issue', query: `involves:${username} updated:${startDate}..${endDate} is:issue` },
-      { type: 'pull-request', query: `involves:${username} updated:${startDate}..${endDate} is:pull-request` },
+      { type: 'issue', query: buildCombinedQuery('issue') },
+      { type: 'pull-request', query: buildCombinedQuery('pull-request') },
     ];
 
     for (const { type, query: searchQuery } of queries) {
@@ -153,7 +164,8 @@ export const useGitHubDataFetching = ({
       while (page <= GITHUB_SEARCH_API_MAX_PAGES) {
         try {
           const typeLabel = type === 'pull-request' ? 'PRs' : 'issues';
-          onProgress(`Fetching ${typeLabel} page ${page} for ${username}...`);
+          const usersLabel = usernames.length === 1 ? usernames[0] : `${usernames.length} users`;
+          onProgress(`Fetching ${typeLabel} page ${page} for ${usersLabel}...`);
 
           const response = await fetch(
             `https://api.github.com/search/issues?q=${encodeURIComponent(searchQuery)}&per_page=${perPage}&page=${page}&sort=updated`,
@@ -171,7 +183,7 @@ export const useGitHubDataFetching = ({
             // Handle pagination limit error (422) - continue with next query
             if (response.status === 422 && responseJSON.message?.includes('pagination')) {
               console.warn(
-                `GitHub Search API pagination limit reached for ${username} ${type} at page ${page}.`
+                `GitHub Search API pagination limit reached for ${type} at page ${page}.`
               );
               break;
             }
@@ -200,7 +212,6 @@ export const useGitHubDataFetching = ({
           }
 
           // Check if we've fetched all items for this query
-          // Stop if we got fewer items than requested OR if we've fetched all available items for this query
           if (items.length < perPage || itemsFetchedForQuery >= totalCount) {
             break;
           }
@@ -211,7 +222,7 @@ export const useGitHubDataFetching = ({
           await new Promise(resolve => setTimeout(resolve, GITHUB_API_DELAY_MS));
 
         } catch (error) {
-          console.error(`Error fetching ${type} page ${page} for ${username}:`, error);
+          console.error(`Error fetching ${type} page ${page}:`, error);
           // Return partial results if we have any, otherwise throw
           if (allItems.length > 0) {
             console.warn(`Returning ${allItems.length} items collected before error`);
@@ -299,28 +310,30 @@ export const useGitHubDataFetching = ({
 
       // Accumulate all data from all users
       const allEvents: GitHubEvent[] = [];
-      const allSearchItems: GitHubItem[] = [];
 
-      // Fetch events for each username with pagination
+      // Fetch all issues/PRs for all users in combined queries (2 API calls total)
+      setCurrentUsername(usernames.length === 1 ? usernames[0] : `${usernames.length} users`);
+      let allSearchItems: GitHubItem[] = [];
+      try {
+        allSearchItems = await fetchAllSearchItemsForUsers(usernames, githubToken, startDate, endDate, onProgress);
+        onProgress(`Fetched ${allSearchItems.length} issues/PRs for ${usernames.length} user(s)`);
+      } catch (error) {
+        console.error('Error fetching issues/PRs:', error);
+        onError(`Error fetching issues/PRs: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      }
+
+      // Fetch events for each username (Events API doesn't support OR queries)
       for (const singleUsername of usernames) {
         setCurrentUsername(singleUsername);
 
         try {
-          // Fetch all issues and PRs with pagination
-          const userSearchItems = await fetchAllSearchItems(singleUsername, githubToken, startDate, endDate, onProgress);
-          allSearchItems.push(...userSearchItems);
-          onProgress(`Fetched ${userSearchItems.length} issues/PRs for ${singleUsername}`);
-
-           // Fetch all events with pagination
-           const userEvents = await fetchAllEvents(singleUsername, githubToken, startDate, endDate, onProgress);
-           allEvents.push(...userEvents);
-           onProgress(`Fetched ${userEvents.length} events for ${singleUsername}`);
-
-
+          const userEvents = await fetchAllEvents(singleUsername, githubToken, startDate, endDate, onProgress);
+          allEvents.push(...userEvents);
+          onProgress(`Fetched ${userEvents.length} events for ${singleUsername}`);
         } catch (error) {
-          console.error(`Error fetching data for ${singleUsername}:`, error);
+          console.error(`Error fetching events for ${singleUsername}:`, error);
           onError(
-            `Error fetching data for ${singleUsername}: ${error instanceof Error ? error.message : 'Unknown error'}`
+            `Error fetching events for ${singleUsername}: ${error instanceof Error ? error.message : 'Unknown error'}`
           );
           // Continue with other usernames instead of breaking
           continue;

--- a/src/hooks/useGitHubDataFetching.ts
+++ b/src/hooks/useGitHubDataFetching.ts
@@ -141,7 +141,7 @@ export const useGitHubDataFetching = ({
     const maxPages = 10; // GitHub Search API allows up to 1000 results (10 pages * 100 per page)
     let totalCount = 0;
 
-    const searchQuery = `(author:${username} OR assignee:${username}) AND updated:${startDate}..${endDate} AND (is:issue OR is:pr)`;
+    const searchQuery = `(author:${username} OR assignee:${username}) updated:${startDate}..${endDate} (is:issue OR is:pull-request)`;
 
     while (page <= maxPages) {
       try {

--- a/src/hooks/useGitHubDataFetching.ts
+++ b/src/hooks/useGitHubDataFetching.ts
@@ -139,6 +139,7 @@ export const useGitHubDataFetching = ({
     let page = 1;
     const perPage = GITHUB_API_PER_PAGE;
     const maxPages = 10; // GitHub Search API allows up to 1000 results (10 pages * 100 per page)
+    let totalCount = 0;
 
     const searchQuery = `(author:${username} OR assignee:${username}) AND updated:${startDate}..${endDate} AND (is:issue OR is:pr)`;
 
@@ -162,7 +163,7 @@ export const useGitHubDataFetching = ({
         }
 
         const searchData = await response.json();
-        const totalCount = searchData.total_count;
+        totalCount = searchData.total_count;
         const items = searchData.items;
 
         // Add original property to search items and ensure assignee data is preserved
@@ -191,11 +192,11 @@ export const useGitHubDataFetching = ({
       }
     }
 
-    // Log if we hit the pagination limit
-    if (page > maxPages) {
+    // Log if we hit the pagination limit but there are more items available
+    if (allItems.length < totalCount) {
       console.warn(
         `Reached GitHub Search API pagination limit (${maxPages} pages) for ${username}. ` +
-        `Returning ${allItems.length} items. GitHub API limits search results to 1000 items.`
+        `Returning ${allItems.length} items out of ${totalCount} total. GitHub API limits search results to 1000 items.`
       );
     }
 

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -2,3 +2,4 @@
 export const MAX_USERNAMES_PER_REQUEST = 15;
 export const GITHUB_API_PER_PAGE = 100;
 export const GITHUB_API_DELAY_MS = 100;
+export const GITHUB_SEARCH_API_MAX_PAGES = 10; // GitHub Search API allows up to 1000 results (10 pages * 100 per page)


### PR DESCRIPTION
When fetching issues with per_page=100 and there are more results, now fetches all follow-up pages up to the GitHub Search API limit of 1000 results (10 pages). Uses total_count from API response to determine when all items have been fetched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented batched search queries for improved performance when searching multiple usernames simultaneously.
  * Enhanced progress notifications to reflect search status updates.

* **Bug Fixes**
  * Improved error handling with partial result recovery during pagination failures.
  * Added deduplication logic to eliminate duplicate items across search results.
  * Enhanced 422 pagination error handling to gracefully store available results.

* **Tests**
  * Added comprehensive pagination test coverage for search functionality, including multi-page scenarios, error conditions, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->