### PR TITLE
Group tabs by users when multiple usernames are configured

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,8 @@ import GitVegasLogo from './assets/GitVegas.svg?react';
 // Form context for sharing form state across components
 interface FormContextType {
   username: string;
+  usernames: string[];
+  isMultiUser: boolean;
   startDate: string;
   endDate: string;
   githubToken: string;
@@ -110,6 +112,12 @@ function App() {
 
   const { username, startDate, endDate, githubToken, apiMode } = formSettings;
 
+  // Parse usernames for multi-user detection
+  const usernames = useMemo(() => {
+    return username ? username.split(',').map(u => u.trim()).filter(Boolean) : [];
+  }, [username]);
+  const isMultiUser = usernames.length > 1;
+
   const {
     results,
     searchItemsCount,
@@ -124,6 +132,7 @@ function App() {
     apiMode,
     searchText,
     githubToken,
+    isMultiUser,
   });
 
   const {
@@ -423,6 +432,8 @@ function App() {
         <FormContext.Provider
           value={{
             username,
+            usernames,
+            isMultiUser,
             startDate,
             endDate,
             githubToken,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,8 @@ interface FormContextType {
   username: string;
   usernames: string[];
   isMultiUser: boolean;
+  groupByUsers: boolean;
+  setGroupByUsers: (value: boolean) => void;
   startDate: string;
   endDate: string;
   githubToken: string;
@@ -79,6 +81,7 @@ function App() {
   const [isManuallySpinning, setIsManuallySpinning] = useState(false);
   const [isDataLoadingComplete, setIsDataLoadingComplete] = useState(false);
   const [searchText, setSearchText] = useLocalStorage('header-search-text', '');
+  const [groupByUsers, setGroupByUsers] = useLocalStorage<boolean>('group-by-users', false);
 
   const handleUrlParamsProcessed = useCallback(() => {
     setInitialLoadingCount(1);
@@ -132,7 +135,7 @@ function App() {
     apiMode,
     searchText,
     githubToken,
-    isMultiUser,
+    isMultiUser: isMultiUser && groupByUsers,
   });
 
   const {
@@ -434,6 +437,8 @@ function App() {
             username,
             usernames,
             isMultiUser,
+            groupByUsers,
+            setGroupByUsers,
             startDate,
             endDate,
             githubToken,

--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -6,6 +6,8 @@ import {
   TextInput,
   Flash,
   UnderlineNav,
+  ToggleSwitch,
+  Text,
 } from '@primer/react';
 import { useFormContext } from '../App';
 import { validateUsernameList, validateGitHubUsernames } from '../utils';
@@ -29,6 +31,9 @@ const SearchForm = memo(function SearchForm() {
     eventsCount,
     // rawEventsCount removed as it's not used
     githubToken,
+    isMultiUser,
+    groupByUsers,
+    setGroupByUsers,
   } = useFormContext();
 
   // Track if validation is in progress
@@ -194,59 +199,92 @@ const SearchForm = memo(function SearchForm() {
           </FormControl>
         </Box>
         {/* API Mode Switch */}
-        <Box 
-          sx={{ 
+        <Box
+          sx={{
             mb: 2,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 3,
             '@media (max-width: 767px)': {
-              overflowX: 'auto',
-              overflowY: 'hidden',
-              '& nav': {
-                whiteSpace: 'nowrap',
-              },
+              flexDirection: 'column',
+              alignItems: 'stretch',
             },
           }}
         >
-          <UnderlineNav 
-            aria-label="GitHub API Mode"
+          <Box
             sx={{
+              flex: 1,
               '@media (max-width: 767px)': {
-                minWidth: 'fit-content',
+                overflowX: 'auto',
+                overflowY: 'hidden',
+                '& nav': {
+                  whiteSpace: 'nowrap',
+                },
               },
             }}
           >
-            <UnderlineNav.Item
-              href="#"
-              aria-current={apiMode === 'summary' ? 'page' : undefined}
-              onSelect={e => {
-                e.preventDefault();
-                setApiMode('summary');
+            <UnderlineNav
+              aria-label="GitHub API Mode"
+              sx={{
+                '@media (max-width: 767px)': {
+                  minWidth: 'fit-content',
+                },
               }}
             >
-              Summary
-            </UnderlineNav.Item>
-            <UnderlineNav.Item
-              href="#"
-              aria-current={apiMode === 'search' ? 'page' : undefined}
-              counter={searchItemsCount > 0 ? searchItemsCount : undefined}
-              onSelect={e => {
-                e.preventDefault();
-                setApiMode('search');
+              <UnderlineNav.Item
+                href="#"
+                aria-current={apiMode === 'summary' ? 'page' : undefined}
+                onSelect={e => {
+                  e.preventDefault();
+                  setApiMode('summary');
+                }}
+              >
+                Summary
+              </UnderlineNav.Item>
+              <UnderlineNav.Item
+                href="#"
+                aria-current={apiMode === 'search' ? 'page' : undefined}
+                counter={searchItemsCount > 0 ? searchItemsCount : undefined}
+                onSelect={e => {
+                  e.preventDefault();
+                  setApiMode('search');
+                }}
+              >
+                GitHub Issues & PRs
+              </UnderlineNav.Item>
+              <UnderlineNav.Item
+                href="#"
+                aria-current={apiMode === 'events' ? 'page' : undefined}
+                counter={eventsCount > 0 ? eventsCount : undefined}
+                onSelect={e => {
+                  e.preventDefault();
+                  setApiMode('events');
+                }}
+              >
+                GitHub Events
+              </UnderlineNav.Item>
+            </UnderlineNav>
+          </Box>
+          {isMultiUser && (
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 2,
+                flexShrink: 0,
               }}
             >
-              GitHub Issues & PRs
-            </UnderlineNav.Item>
-            <UnderlineNav.Item
-              href="#"
-              aria-current={apiMode === 'events' ? 'page' : undefined}
-              counter={eventsCount > 0 ? eventsCount : undefined}
-              onSelect={e => {
-                e.preventDefault();
-                setApiMode('events');
-              }}
-            >
-              GitHub Events
-            </UnderlineNav.Item>
-          </UnderlineNav>
+              <Text sx={{ fontSize: 1, color: 'fg.muted', whiteSpace: 'nowrap' }}>
+                Group by users
+              </Text>
+              <ToggleSwitch
+                size="small"
+                checked={groupByUsers}
+                onChange={() => setGroupByUsers(!groupByUsers)}
+                aria-label="Group by users"
+              />
+            </Box>
+          )}
         </Box>
       </Box>
 

--- a/src/utils/rawDataUtils.ts
+++ b/src/utils/rawDataUtils.ts
@@ -582,7 +582,8 @@ export const processRawEvents = (
 export const categorizeRawSearchItems = (
   rawItems: GitHubItem[],
   startDate?: string,
-  endDate?: string
+  endDate?: string,
+  skipDedup = false
 ): GitHubItem[] => {
   // Set up date filtering if dates are provided
   const startDateTime = startDate ? new Date(startDate).getTime() : 0;
@@ -595,7 +596,7 @@ export const categorizeRawSearchItems = (
       console.warn('Skipping item with missing title:', item.html_url || item.id);
       return false;
     }
-    
+
     const itemTime = new Date(item.updated_at).getTime();
 
     // Filter by date range if dates are provided
@@ -609,10 +610,15 @@ export const categorizeRawSearchItems = (
     return true;
   });
 
+  // Skip deduplication in multi-user mode to preserve per-user items
+  if (skipDedup) {
+    return dateFilteredItems;
+  }
+
   // Then remove duplicates based on html_url (unique identifier for issues/PRs)
   const urlSet = new Set<string>();
   const deduplicatedItems: GitHubItem[] = [];
-  
+
   dateFilteredItems.forEach(item => {
     if (!urlSet.has(item.html_url)) {
       urlSet.add(item.html_url);

--- a/src/views/EventView.tsx
+++ b/src/views/EventView.tsx
@@ -1,10 +1,19 @@
-import { memo, useCallback, useEffect } from 'react';
+import React, { memo, useCallback, useEffect, useMemo } from 'react';
 import {
   Text,
   Checkbox,
   Box,
   Pagination,
+  Button,
+  Heading,
+  Avatar,
+  Token,
 } from '@primer/react';
+import {
+  ChevronDownIcon,
+  ChevronUpIcon,
+  PeopleIcon,
+} from '@primer/octicons-react';
 import { GitHubItem, GitHubEvent, getItemId } from '../types';
 import { ResultsContainer } from '../components/ResultsContainer';
 
@@ -29,25 +38,88 @@ interface EventViewProps {
   rawEvents?: GitHubEvent[];
 }
 
+/** Groups items by user login, preserving configured user order. */
+const groupItemsByUser = (
+  items: GitHubItem[],
+  configuredUsernames: string[]
+): Record<string, GitHubItem[]> => {
+  const userGroups: Record<string, GitHubItem[]> = {};
+  const configuredLower = configuredUsernames.map(u => u.toLowerCase());
+
+  items.forEach(item => {
+    const login = item.user.login;
+    if (!userGroups[login]) {
+      userGroups[login] = [];
+    }
+    userGroups[login].push(item);
+  });
+
+  const ordered: Record<string, GitHubItem[]> = {};
+  for (const configUser of configuredUsernames) {
+    const matchKey = Object.keys(userGroups).find(
+      k => k.toLowerCase() === configUser.toLowerCase()
+    );
+    if (matchKey && userGroups[matchKey].length > 0) {
+      ordered[matchKey] = userGroups[matchKey];
+    }
+  }
+  Object.keys(userGroups)
+    .filter(k => !configuredLower.includes(k.toLowerCase()))
+    .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
+    .forEach(k => {
+      if (userGroups[k].length > 0) {
+        ordered[k] = userGroups[k];
+      }
+    });
+
+  return ordered;
+};
+
 const EventView = memo(function EventView({
   items,
   rawEvents = [],
 }: EventViewProps) {
-  const { searchText, setSearchText } = useFormContext();
+  const { searchText, setSearchText, isMultiUser, usernames } = useFormContext();
 
-  // Pagination state
+  // Pagination state (per-section for multi-user, single for single-user)
   const [currentPage, setCurrentPage] = useLocalStorage<number>('eventView-currentPage', 1);
+  const [sectionPages, setSectionPages] = useLocalStorage<Record<string, number>>('eventView-sectionPages', {});
+  const [collapsedSections, setCollapsedSections] = useLocalStorage<Set<string>>('eventView-collapsedSections', new Set());
   const itemsPerPage = 100;
+
+  const getSectionPage = useCallback((sectionName: string) => {
+    return sectionPages[sectionName] || 1;
+  }, [sectionPages]);
+
+  const setSectionPage = useCallback((sectionName: string, page: number) => {
+    setSectionPages(prev => ({ ...prev, [sectionName]: page }));
+  }, [setSectionPages]);
 
   // Filter and sort items
   const filteredItems = filterItemsByAdvancedSearch(items, searchText);
   const sortedItems = sortItemsByUpdatedDate(filteredItems);
 
+  // --- Multi-user grouping ---
+  const perUserItems = useMemo(() => {
+    if (!isMultiUser) return null;
+    return groupItemsByUser(sortedItems, usernames);
+  }, [isMultiUser, sortedItems, usernames]);
+
+  // Build flat list of displayed items for selection
+  const allDisplayedItems = useMemo(() => {
+    if (isMultiUser && perUserItems) {
+      return Object.entries(perUserItems)
+        .filter(([login]) => !collapsedSections.has(`@user:${login}`))
+        .flatMap(([, items]) => items);
+    }
+    return sortedItems;
+  }, [isMultiUser, perUserItems, sortedItems, collapsedSections]);
+
   // Shared hooks
   const {
     selectedItems, toggleItemSelection, selectAllItems, clearSelection,
-    selectAllState,
-  } = useListSelection('eventView-selectedItems', sortedItems);
+    bulkSelectItems, selectAllState,
+  } = useListSelection('eventView-selectedItems', allDisplayedItems);
 
   const {
     selectedItemForDialog, setSelectedItemForDialog,
@@ -59,12 +131,34 @@ const EventView = memo(function EventView({
   // Reset to first page when search changes
   useEffect(() => {
     setCurrentPage(1);
-  }, [searchText, setCurrentPage]);
+    setSectionPages({});
+  }, [searchText, setCurrentPage, setSectionPages]);
 
-  // Pagination
+  // Single-user pagination
   const totalPages = Math.ceil(sortedItems.length / itemsPerPage);
   const startIndex = (currentPage - 1) * itemsPerPage;
   const paginatedItems = sortedItems.slice(startIndex, startIndex + itemsPerPage);
+
+  // Toggle section collapse
+  const toggleSectionCollapse = useCallback((sectionName: string) => {
+    setCollapsedSections(prev => {
+      const newSet = new Set(prev);
+      if (newSet.has(sectionName)) {
+        newSet.delete(sectionName);
+      } else {
+        newSet.add(sectionName);
+        if (isMultiUser && perUserItems) {
+          const login = sectionName.replace('@user:', '');
+          const userItems = perUserItems[login];
+          if (userItems) {
+            const idsToRemove = userItems.map(item => getItemId(item));
+            bulkSelectItems(idsToRemove, false);
+          }
+        }
+      }
+      return newSet;
+    });
+  }, [isMultiUser, perUserItems, bulkSelectItems]);
 
   // Copy handler
   const copyResultsToClipboard = useCallback(async (format: 'detailed' | 'compact') => {
@@ -108,7 +202,7 @@ const EventView = memo(function EventView({
             />
             <Text sx={{ fontSize: 1, color: 'fg.default', m: 0 }}>
               Select All
-              {totalPages > 1 && (
+              {!isMultiUser && totalPages > 1 && (
                 <Text as="span" sx={{ fontSize: 1, color: 'fg.muted', ml: 2 }}>
                   (Page {currentPage} of {totalPages})
                 </Text>
@@ -138,7 +232,90 @@ const EventView = memo(function EventView({
             showClearSearch={!!searchText}
             onClearSearch={() => setSearchText('')}
           />
+        ) : isMultiUser && perUserItems ? (
+          // Multi-user: group by user
+          Object.entries(perUserItems).map(([login, userItems]) => {
+            if (userItems.length === 0) return null;
+            const userCollapseKey = `@user:${login}`;
+            const isUserCollapsed = collapsedSections.has(userCollapseKey);
+            const avatarUrl = userItems[0]?.user?.avatar_url;
+
+            // Per-user pagination
+            const userPage = getSectionPage(login);
+            const userTotalPages = Math.ceil(userItems.length / itemsPerPage);
+            const userStartIndex = (userPage - 1) * itemsPerPage;
+            const paginatedUserItems = userItems.slice(userStartIndex, userStartIndex + itemsPerPage);
+
+            return (
+              <div key={login} className="timeline-section" style={{ marginBottom: '1rem' }}>
+                <div className="timeline-section-header">
+                  <Box sx={{ display: 'flex', alignItems: 'center', width: '100%', mb: 2 }}>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flex: 1 }}>
+                      {avatarUrl ? (
+                        <Avatar src={avatarUrl} size={20} alt={login} />
+                      ) : (
+                        <PeopleIcon size={16} />
+                      )}
+                      <Heading as="h2" sx={{ fontSize: 2, fontWeight: 'bold', m: 0 }}>
+                        {login}
+                      </Heading>
+                      <Token
+                        text={`${userItems.length}`}
+                        size="small"
+                        sx={{ ml: 2, flexShrink: 0 }}
+                      />
+                    </Box>
+                    <Button
+                      variant="invisible"
+                      size="small"
+                      onClick={() => toggleSectionCollapse(userCollapseKey)}
+                      className="timeline-section-collapse-button"
+                      sx={{
+                        fontSize: '0.75rem',
+                        color: 'fg.muted',
+                        flexShrink: 0,
+                        '&:hover': { color: 'fg.default' },
+                      }}
+                      aria-label={`${isUserCollapsed ? 'Show' : 'Hide'} ${login} section`}
+                    >
+                      {isUserCollapsed ? <ChevronUpIcon size={16} /> : <ChevronDownIcon size={16} />}
+                    </Button>
+                  </Box>
+                </div>
+                {!isUserCollapsed && (
+                  <Box sx={{ pl: 3 }}>
+                    {paginatedUserItems.map((item: GitHubItem, index: number) => (
+                      <ItemRow
+                        key={`${item.id}-${index}`}
+                        item={item}
+                        onShowDescription={setSelectedItemForDialog}
+                        selected={selectedItems.has(getItemId(item))}
+                        onSelect={toggleItemSelection}
+                        showCheckbox={true}
+                        showRepo={true}
+                        showTime={true}
+                        size="small"
+                      />
+                    ))}
+                    {userTotalPages > 1 && (
+                      <Box sx={{ display: 'flex', justifyContent: 'center', mt: 4, pb: 3 }}>
+                        <Pagination
+                          pageCount={userTotalPages}
+                          currentPage={userPage}
+                          onPageChange={(_event: React.MouseEvent, page: number) => setSectionPage(login, page)}
+                          showPages={{ narrow: false }}
+                          marginPageCount={2}
+                          surroundingPageCount={2}
+                        />
+                      </Box>
+                    )}
+                  </Box>
+                )}
+              </div>
+            );
+          })
         ) : (
+          // Single-user: existing behavior
           <>
             {paginatedItems.map((item: GitHubItem, index: number) => (
               <ItemRow

--- a/src/views/IssuesAndPRsList.tsx
+++ b/src/views/IssuesAndPRsList.tsx
@@ -6,6 +6,8 @@ import {
   Button,
   Heading,
   Pagination,
+  Avatar,
+  Token,
 } from '@primer/react';
 import {
   GitPullRequestIcon,
@@ -14,6 +16,7 @@ import {
   GitPullRequestDraftIcon,
   ChevronDownIcon,
   ChevronUpIcon,
+  PeopleIcon,
 } from '@primer/octicons-react';
 
 import { GitHubItem, getItemId } from '../types';
@@ -107,12 +110,49 @@ const SectionContent = ({
   );
 };
 
+/** Groups items by user login, preserving configured user order. */
+const groupItemsByUser = (
+  items: GitHubItem[],
+  configuredUsernames: string[]
+): Record<string, GitHubItem[]> => {
+  const userGroups: Record<string, GitHubItem[]> = {};
+  const configuredLower = configuredUsernames.map(u => u.toLowerCase());
+
+  items.forEach(item => {
+    const login = item.user.login;
+    if (!userGroups[login]) {
+      userGroups[login] = [];
+    }
+    userGroups[login].push(item);
+  });
+
+  const ordered: Record<string, GitHubItem[]> = {};
+  for (const configUser of configuredUsernames) {
+    const matchKey = Object.keys(userGroups).find(
+      k => k.toLowerCase() === configUser.toLowerCase()
+    );
+    if (matchKey && userGroups[matchKey].length > 0) {
+      ordered[matchKey] = userGroups[matchKey];
+    }
+  }
+  Object.keys(userGroups)
+    .filter(k => !configuredLower.includes(k.toLowerCase()))
+    .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
+    .forEach(k => {
+      if (userGroups[k].length > 0) {
+        ordered[k] = userGroups[k];
+      }
+    });
+
+  return ordered;
+};
+
 const IssuesAndPRsList = memo(function IssuesAndPRsList({
   results,
 }: {
   results: GitHubItem[];
 }) {
-  const { searchText, setSearchText } = useFormContext();
+  const { searchText, setSearchText, isMultiUser, usernames } = useFormContext();
 
   const [collapsedSections, setCollapsedSections] = useLocalStorage<Set<string>>('issuesAndPRs-collapsedSections', new Set());
 
@@ -143,7 +183,32 @@ const IssuesAndPRsList = memo(function IssuesAndPRsList({
   const hasRawData = results && results.length > 0;
   const hasSearchText = searchText && searchText.trim().length > 0;
 
+  // --- Multi-user grouping ---
+  const perUserGroupedItems = useMemo(() => {
+    if (!isMultiUser) return null;
+    const userItems = groupItemsByUser(filteredResults, usernames);
+    const result: Record<string, { 'PRs': GitHubItem[]; 'Issues': GitHubItem[] }> = {};
+
+    for (const [login, items] of Object.entries(userItems)) {
+      const groups: { 'PRs': GitHubItem[]; 'Issues': GitHubItem[] } = { 'PRs': [], 'Issues': [] };
+      items.forEach(item => {
+        if (item.pull_request) {
+          groups['PRs'].push(item);
+        } else {
+          groups['Issues'].push(item);
+        }
+      });
+      Object.keys(groups).forEach(key => {
+        groups[key as keyof typeof groups] = sortItemsByUpdatedDate(groups[key as keyof typeof groups]);
+      });
+      result[login] = groups;
+    }
+    return result;
+  }, [isMultiUser, filteredResults, usernames]);
+
+  // --- Single-user grouping (existing logic) ---
   const groupedItems = useMemo(() => {
+    if (isMultiUser) return { 'PRs': [] as GitHubItem[], 'Issues': [] as GitHubItem[] };
     const groups: { 'PRs': GitHubItem[]; 'Issues': GitHubItem[] } = { 'PRs': [], 'Issues': [] };
     filteredResults.forEach(item => {
       if (item.pull_request) {
@@ -156,14 +221,23 @@ const IssuesAndPRsList = memo(function IssuesAndPRsList({
       groups[key as keyof typeof groups] = sortItemsByUpdatedDate(groups[key as keyof typeof groups]);
     });
     return groups;
-  }, [filteredResults]);
+  }, [isMultiUser, filteredResults]);
 
   // Build flat list of items from expanded sections for selection
   const allDisplayedItems = useMemo(() => {
+    if (isMultiUser && perUserGroupedItems) {
+      return Object.entries(perUserGroupedItems)
+        .filter(([login]) => !collapsedSections.has(`@user:${login}`))
+        .flatMap(([login, groups]) =>
+          Object.entries(groups)
+            .filter(([groupName]) => !collapsedSections.has(`@user:${login}/${groupName}`))
+            .flatMap(([, items]) => items)
+        );
+    }
     return Object.entries(groupedItems)
       .filter(([groupName]) => !collapsedSections.has(groupName))
       .flatMap(([, items]) => items);
-  }, [groupedItems, collapsedSections]);
+  }, [isMultiUser, perUserGroupedItems, groupedItems, collapsedSections]);
 
   // Shared hooks
   const {
@@ -184,25 +258,50 @@ const IssuesAndPRsList = memo(function IssuesAndPRsList({
         newSet.delete(sectionName);
       } else {
         newSet.add(sectionName);
-        const sectionItems = groupedItems[sectionName as keyof typeof groupedItems] || [];
-        if (sectionItems.length > 0) {
-          const idsToRemove = sectionItems.map(item => getItemId(item));
-          bulkSelectItems(idsToRemove, false);
+        if (isMultiUser && perUserGroupedItems) {
+          if (sectionName.startsWith('@user:') && !sectionName.includes('/')) {
+            const login = sectionName.replace('@user:', '');
+            const userGroups = perUserGroupedItems[login];
+            if (userGroups) {
+              const idsToRemove = Object.values(userGroups).flat().map(item => getItemId(item));
+              bulkSelectItems(idsToRemove, false);
+            }
+          } else if (sectionName.includes('/')) {
+            const [userPart, groupName] = sectionName.split('/');
+            const login = userPart.replace('@user:', '');
+            const userGroups = perUserGroupedItems[login];
+            if (userGroups && userGroups[groupName as keyof typeof userGroups]) {
+              const idsToRemove = userGroups[groupName as keyof typeof userGroups].map(item => getItemId(item));
+              bulkSelectItems(idsToRemove, false);
+            }
+          }
+        } else {
+          const sectionItems = groupedItems[sectionName as keyof typeof groupedItems] || [];
+          if (sectionItems.length > 0) {
+            const idsToRemove = sectionItems.map(item => getItemId(item));
+            bulkSelectItems(idsToRemove, false);
+          }
         }
       }
       return newSet;
     });
-  }, [groupedItems, bulkSelectItems]);
+  }, [isMultiUser, perUserGroupedItems, groupedItems, bulkSelectItems]);
 
   // Copy handler
   const copyResultsToClipboard = useCallback(async (format: 'detailed' | 'compact') => {
-    const groupedData = Object.entries(groupedItems)
-      .filter(([, items]) => items.length > 0)
-      .map(([groupName, items]) => ({ groupName, items }));
+    const allGroups = isMultiUser && perUserGroupedItems
+      ? Object.entries(perUserGroupedItems).flatMap(([login, groups]) =>
+          Object.entries(groups)
+            .filter(([, items]) => items.length > 0)
+            .map(([groupName, items]) => ({ groupName: `${login} - ${groupName}`, items }))
+        )
+      : Object.entries(groupedItems)
+          .filter(([, items]) => items.length > 0)
+          .map(([groupName, items]) => ({ groupName, items }));
 
-    let finalGroupedData = groupedData;
+    let finalGroupedData = allGroups;
     if (selectedItems.size > 0) {
-      finalGroupedData = groupedData
+      finalGroupedData = allGroups
         .map(group => ({
           ...group,
           items: group.items.filter(item => selectedItems.has(getItemId(item))),
@@ -210,7 +309,7 @@ const IssuesAndPRsList = memo(function IssuesAndPRsList({
         .filter(group => group.items.length > 0);
     }
 
-    const allItems = Object.values(groupedItems).flat();
+    const allItems = allGroups.flatMap(g => g.items);
     const selectedItemsArray =
       selectedItems.size > 0
         ? allItems.filter(item => selectedItems.has(getItemId(item)))
@@ -223,7 +322,7 @@ const IssuesAndPRsList = memo(function IssuesAndPRsList({
       onSuccess: () => triggerCopy(format),
       onError: (error: Error) => console.error('Failed to copy grouped results:', error),
     });
-  }, [groupedItems, selectedItems, triggerCopy]);
+  }, [isMultiUser, perUserGroupedItems, groupedItems, selectedItems, triggerCopy]);
 
   // Select all toggle
   const handleSelectAllChange = () => {
@@ -232,6 +331,69 @@ const IssuesAndPRsList = memo(function IssuesAndPRsList({
     } else {
       selectAllItems();
     }
+  };
+
+  /** Renders a PRs/Issues group section. */
+  const renderGroupSection = (
+    groupName: string,
+    groupItems: GitHubItem[],
+    collapseKey: string,
+  ) => {
+    if (groupItems.length === 0) return null;
+    const isCollapsed = collapsedSections.has(collapseKey);
+
+    return (
+      <div key={collapseKey} className="timeline-section">
+        <div className="timeline-section-header">
+          <Box sx={{ display: 'flex', alignItems: 'center', width: '100%', mb: 2 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flex: 1 }}>
+              <Checkbox
+                {...getGroupSelectState(groupItems, selectedItems)}
+                onChange={() => {
+                  if (isCollapsed) return;
+                  const sectionItemIds = groupItems.map(getItemId);
+                  const allSelected = sectionItemIds.every(id => selectedItems.has(id));
+                  bulkSelectItems(sectionItemIds, !allSelected);
+                }}
+                sx={{ flexShrink: 0 }}
+                aria-label={`Select all items in ${groupName} section`}
+                disabled={isCollapsed}
+              />
+              <Heading as="h3" sx={{ fontSize: 1, fontWeight: 'bold', m: 0 }}>
+                {groupName} ({groupItems.length})
+              </Heading>
+            </Box>
+            <Button
+              variant="invisible"
+              size="small"
+              onClick={() => toggleSectionCollapse(collapseKey)}
+              className="timeline-section-collapse-button"
+              sx={{
+                fontSize: '0.75rem',
+                color: 'fg.muted',
+                flexShrink: 0,
+                '&:hover': { color: 'fg.default' },
+              }}
+              aria-label={`${isCollapsed ? 'Show' : 'Hide'} ${groupName} section`}
+            >
+              {isCollapsed ? <ChevronUpIcon size={16} /> : <ChevronDownIcon size={16} />}
+            </Button>
+          </Box>
+        </div>
+        {!isCollapsed && (
+          <SectionContent
+            groupName={collapseKey}
+            groupItems={groupItems}
+            itemsPerPage={itemsPerPage}
+            getSectionPage={getSectionPage}
+            setSectionPage={setSectionPage}
+            selectedItems={selectedItems}
+            toggleItemSelection={toggleItemSelection}
+            setSelectedItemForDialog={setSelectedItemForDialog}
+          />
+        )}
+      </div>
+    );
   };
 
   return (
@@ -269,35 +431,40 @@ const IssuesAndPRsList = memo(function IssuesAndPRsList({
               showClearSearch={!!searchText}
               onClearSearch={() => setSearchText('')}
             />
-          ) : (
+          ) : isMultiUser && perUserGroupedItems ? (
+            // Multi-user: group by user, then by PRs/Issues
             <div className="timeline-content">
-              {Object.entries(groupedItems).map(([groupName, groupItems]) => {
-                if (groupItems.length === 0) return null;
+              {Object.entries(perUserGroupedItems).map(([login, groups]) => {
+                const userItemCount = Object.values(groups).reduce((sum, items) => sum + items.length, 0);
+                if (userItemCount === 0) return null;
+                const userCollapseKey = `@user:${login}`;
+                const isUserCollapsed = collapsedSections.has(userCollapseKey);
+                const firstItem = Object.values(groups).flat()[0];
+                const avatarUrl = firstItem?.user?.avatar_url;
+
                 return (
-                  <div key={groupName} className="timeline-section">
+                  <div key={login} className="timeline-section" style={{ marginBottom: '1rem' }}>
                     <div className="timeline-section-header">
                       <Box sx={{ display: 'flex', alignItems: 'center', width: '100%', mb: 2 }}>
                         <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flex: 1 }}>
-                          <Checkbox
-                            {...getGroupSelectState(groupItems, selectedItems)}
-                            onChange={() => {
-                              if (collapsedSections.has(groupName)) return;
-                              const sectionItemIds = groupItems.map(getItemId);
-                              const allSelected = sectionItemIds.every(id => selectedItems.has(id));
-                              bulkSelectItems(sectionItemIds, !allSelected);
-                            }}
-                            sx={{ flexShrink: 0 }}
-                            aria-label={`Select all items in ${groupName} section`}
-                            disabled={collapsedSections.has(groupName)}
-                          />
-                          <Heading as="h3" sx={{ fontSize: 1, fontWeight: 'bold', m: 0 }}>
-                            {groupName} ({groupItems.length})
+                          {avatarUrl ? (
+                            <Avatar src={avatarUrl} size={20} alt={login} />
+                          ) : (
+                            <PeopleIcon size={16} />
+                          )}
+                          <Heading as="h2" sx={{ fontSize: 2, fontWeight: 'bold', m: 0 }}>
+                            {login}
                           </Heading>
+                          <Token
+                            text={`${userItemCount}`}
+                            size="small"
+                            sx={{ ml: 2, flexShrink: 0 }}
+                          />
                         </Box>
                         <Button
                           variant="invisible"
                           size="small"
-                          onClick={() => toggleSectionCollapse(groupName)}
+                          onClick={() => toggleSectionCollapse(userCollapseKey)}
                           className="timeline-section-collapse-button"
                           sx={{
                             fontSize: '0.75rem',
@@ -305,27 +472,29 @@ const IssuesAndPRsList = memo(function IssuesAndPRsList({
                             flexShrink: 0,
                             '&:hover': { color: 'fg.default' },
                           }}
-                          aria-label={`${collapsedSections.has(groupName) ? 'Show' : 'Hide'} ${groupName} section`}
+                          aria-label={`${isUserCollapsed ? 'Show' : 'Hide'} ${login} section`}
                         >
-                          {collapsedSections.has(groupName) ? <ChevronUpIcon size={16} /> : <ChevronDownIcon size={16} />}
+                          {isUserCollapsed ? <ChevronUpIcon size={16} /> : <ChevronDownIcon size={16} />}
                         </Button>
                       </Box>
                     </div>
-                    {!collapsedSections.has(groupName) && (
-                      <SectionContent
-                        groupName={groupName}
-                        groupItems={groupItems}
-                        itemsPerPage={itemsPerPage}
-                        getSectionPage={getSectionPage}
-                        setSectionPage={setSectionPage}
-                        selectedItems={selectedItems}
-                        toggleItemSelection={toggleItemSelection}
-                        setSelectedItemForDialog={setSelectedItemForDialog}
-                      />
+                    {!isUserCollapsed && (
+                      <Box sx={{ pl: 3 }}>
+                        {Object.entries(groups).map(([groupName, groupItems]) =>
+                          renderGroupSection(groupName, groupItems, `@user:${login}/${groupName}`)
+                        )}
+                      </Box>
                     )}
                   </div>
                 );
               })}
+            </div>
+          ) : (
+            // Single-user: existing behavior
+            <div className="timeline-content">
+              {Object.entries(groupedItems).map(([groupName, groupItems]) =>
+                renderGroupSection(groupName, groupItems, groupName)
+              )}
             </div>
           )}
         </div>

--- a/src/views/Summary.tsx
+++ b/src/views/Summary.tsx
@@ -6,10 +6,12 @@ import {
   Checkbox,
   Box,
   Token,
+  Avatar,
 } from '@primer/react';
 import {
   ChevronDownIcon,
   ChevronUpIcon,
+  PeopleIcon,
 } from '@primer/octicons-react';
 import { GitHubItem, GitHubEvent, getItemId } from '../types';
 
@@ -67,12 +69,52 @@ const groupItemsByUrl = (groupItems: GitHubItem[]): Record<string, GitHubItem[]>
   return urlGroups;
 };
 
+/** Groups items by user login, preserving configured user order. */
+const groupItemsByUser = (
+  items: GitHubItem[],
+  configuredUsernames: string[]
+): Record<string, GitHubItem[]> => {
+  const userGroups: Record<string, GitHubItem[]> = {};
+  const configuredLower = configuredUsernames.map(u => u.toLowerCase());
+
+  items.forEach(item => {
+    const login = item.user.login;
+    if (!userGroups[login]) {
+      userGroups[login] = [];
+    }
+    userGroups[login].push(item);
+  });
+
+  // Order: configured users first (in order), then others alphabetically
+  const ordered: Record<string, GitHubItem[]> = {};
+  for (const configUser of configuredUsernames) {
+    // Find the actual case-sensitive key that matches
+    const matchKey = Object.keys(userGroups).find(
+      k => k.toLowerCase() === configUser.toLowerCase()
+    );
+    if (matchKey && userGroups[matchKey].length > 0) {
+      ordered[matchKey] = userGroups[matchKey];
+    }
+  }
+  // Add remaining users not in configured list
+  Object.keys(userGroups)
+    .filter(k => !configuredLower.includes(k.toLowerCase()))
+    .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
+    .forEach(k => {
+      if (userGroups[k].length > 0) {
+        ordered[k] = userGroups[k];
+      }
+    });
+
+  return ordered;
+};
+
 const SummaryView = memo(function SummaryView({
   items,
   rawEvents = [],
   indexedDBSearchItems = [],
 }: SummaryProps) {
-  const { startDate, endDate, searchText, setSearchText } = useFormContext();
+  const { startDate, endDate, searchText, setSearchText, isMultiUser, usernames } = useFormContext();
 
   const [collapsedSections, setCollapsedSections] = useLocalStorage<Set<string>>('summary-collapsedSections', new Set());
 
@@ -85,17 +127,67 @@ const SummaryView = memo(function SummaryView({
     return filterItemsByAdvancedSearch(indexedDBSearchItems, searchText);
   }, [indexedDBSearchItems, searchText]);
 
-  // Group items for summary view
-  const actionGroups = useMemo(() => {
+  // --- Multi-user grouping ---
+  type UserActionGroups = Record<string, Record<string, GitHubItem[]>>;
+  const perUserActionGroups = useMemo((): UserActionGroups | null => {
+    if (!isMultiUser) return null;
+    const userItems = groupItemsByUser(sortedItems, usernames);
+    const userSearchItems = groupItemsByUser(filteredIndexedDBSearchItems, usernames);
+
+    const result: Record<string, Record<string, GitHubItem[]>> = {};
+    // Process all users that appear in either items or search items
+    const allUsers = new Set([...Object.keys(userItems), ...Object.keys(userSearchItems)]);
+    for (const login of allUsers) {
+      result[login] = groupSummaryData(
+        userItems[login] || [],
+        userSearchItems[login] || [],
+        startDate,
+        endDate
+      );
+    }
+
+    // Re-order by configured usernames first
+    const configuredLower = usernames.map(u => u.toLowerCase());
+    const ordered: Record<string, Record<string, GitHubItem[]>> = {};
+    for (const configUser of usernames) {
+      const matchKey = Object.keys(result).find(
+        k => k.toLowerCase() === configUser.toLowerCase()
+      );
+      if (matchKey) {
+        ordered[matchKey] = result[matchKey];
+      }
+    }
+    Object.keys(result)
+      .filter(k => !configuredLower.includes(k.toLowerCase()))
+      .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
+      .forEach(k => {
+        ordered[k] = result[k];
+      });
+
+    return ordered;
+  }, [isMultiUser, sortedItems, filteredIndexedDBSearchItems, usernames, startDate, endDate]);
+
+  // --- Single-user grouping (existing logic) ---
+  const actionGroups = useMemo((): Record<string, GitHubItem[]> => {
+    if (isMultiUser) return {};
     return groupSummaryData(sortedItems, filteredIndexedDBSearchItems, startDate, endDate);
-  }, [sortedItems, filteredIndexedDBSearchItems, startDate, endDate]);
+  }, [isMultiUser, sortedItems, filteredIndexedDBSearchItems, startDate, endDate]);
 
   // Build flat list of items from expanded sections for selection
-  const allDisplayedItems = useMemo(() => {
+  const allDisplayedItems = useMemo((): GitHubItem[] => {
+    if (isMultiUser && perUserActionGroups) {
+      return Object.entries(perUserActionGroups)
+        .filter(([login]) => !collapsedSections.has(`@user:${login}`))
+        .flatMap(([login, groups]) =>
+          Object.entries(groups)
+            .filter(([groupName]) => !collapsedSections.has(`@user:${login}/${groupName}`))
+            .flatMap(([, items]) => items)
+        );
+    }
     return Object.entries(actionGroups)
       .filter(([groupName]) => !collapsedSections.has(groupName))
       .flatMap(([, items]) => items);
-  }, [actionGroups, collapsedSections]);
+  }, [isMultiUser, perUserActionGroups, actionGroups, collapsedSections]);
 
   // Shared hooks
   const {
@@ -110,6 +202,21 @@ const SummaryView = memo(function SummaryView({
 
   const { isCopied, triggerCopy } = useCopyFeedback(2000);
 
+  // Get all action groups flattened (for copy and other operations)
+  const allActionGroups = useMemo(() => {
+    if (isMultiUser && perUserActionGroups) {
+      const merged: Record<string, GitHubItem[]> = {};
+      Object.entries(perUserActionGroups).forEach(([login, groups]) => {
+        Object.entries(groups).forEach(([groupName, items]) => {
+          const key = `${login} - ${groupName}`;
+          merged[key] = items;
+        });
+      });
+      return merged;
+    }
+    return actionGroups;
+  }, [isMultiUser, perUserActionGroups, actionGroups]);
+
   // Toggle section collapse and clear selections on collapse
   const toggleSectionCollapse = useCallback((sectionName: string) => {
     setCollapsedSections(prev => {
@@ -118,20 +225,43 @@ const SummaryView = memo(function SummaryView({
         newSet.delete(sectionName);
       } else {
         newSet.add(sectionName);
-        const sectionItems = actionGroups[sectionName as keyof typeof actionGroups] || [];
-        if (sectionItems.length > 0) {
-          const idsToRemove = sectionItems.map(item => getItemId(item));
-          bulkSelectItems(idsToRemove, false);
+        // Find items in this section to deselect
+        if (isMultiUser && perUserActionGroups) {
+          // Could be a user section or a group within a user
+          if (sectionName.startsWith('@user:') && !sectionName.includes('/')) {
+            // User section - deselect all items for this user
+            const login = sectionName.replace('@user:', '');
+            const userGroups = perUserActionGroups[login];
+            if (userGroups) {
+              const idsToRemove = Object.values(userGroups).flat().map(item => getItemId(item));
+              bulkSelectItems(idsToRemove, false);
+            }
+          } else if (sectionName.includes('/')) {
+            // Action group within a user
+            const [userPart, groupName] = sectionName.split('/');
+            const login = userPart.replace('@user:', '');
+            const userGroups = perUserActionGroups[login];
+            if (userGroups && userGroups[groupName]) {
+              const idsToRemove = userGroups[groupName].map(item => getItemId(item));
+              bulkSelectItems(idsToRemove, false);
+            }
+          }
+        } else {
+          const sectionItems = actionGroups[sectionName as keyof typeof actionGroups] || [];
+          if (sectionItems.length > 0) {
+            const idsToRemove = sectionItems.map(item => getItemId(item));
+            bulkSelectItems(idsToRemove, false);
+          }
         }
       }
       return newSet;
     });
-  }, [actionGroups, bulkSelectItems]);
+  }, [isMultiUser, perUserActionGroups, actionGroups, bulkSelectItems]);
 
   // Copy handler
   const copyResultsToClipboard = useCallback(async (format: 'detailed' | 'compact') => {
-    const groupedData = formatGroupedDataForClipboard(actionGroups, selectedItems);
-    const allItems = getAllDisplayedItems(actionGroups);
+    const groupedData = formatGroupedDataForClipboard(allActionGroups, selectedItems);
+    const allItems = getAllDisplayedItems(allActionGroups);
     const selectedItemsArray =
       selectedItems.size > 0
         ? allItems.filter(item => selectedItems.has(getItemId(item)))
@@ -144,7 +274,7 @@ const SummaryView = memo(function SummaryView({
       onSuccess: () => triggerCopy(format),
       onError: (error: Error) => console.error('Failed to copy grouped results:', error),
     });
-  }, [actionGroups, selectedItems, triggerCopy]);
+  }, [allActionGroups, selectedItems, triggerCopy]);
 
   // Select all toggle
   const handleSelectAllChange = () => {
@@ -157,7 +287,87 @@ const SummaryView = memo(function SummaryView({
 
   const hasRawEvents = rawEvents && rawEvents.length > 0;
   const hasSearchText = searchText && searchText.trim().length > 0;
-  const hasItems = Object.values(actionGroups).some(items => items.length > 0);
+  const hasItems = isMultiUser && perUserActionGroups
+    ? Object.values(perUserActionGroups).some(groups =>
+        Object.values(groups).some(items => items.length > 0)
+      )
+    : Object.values(actionGroups).some(items => items.length > 0);
+
+  /** Renders the action group sections (shared between single and multi-user). */
+  const renderActionGroup = (
+    groupName: string,
+    groupItems: GitHubItem[],
+    collapseKey: string,
+  ) => {
+    if (groupItems.length === 0) return null;
+    const urlGroups = groupItemsByUrl(groupItems);
+    const mostRecentIds = Object.values(urlGroups).map(items => getItemId(getMostRecent(items)));
+    const selectedCount = mostRecentIds.filter(id => selectedItems.has(id)).length;
+    const isCollapsed = collapsedSections.has(collapseKey);
+
+    return (
+      <div key={collapseKey} className="timeline-section">
+        <div className="timeline-section-header">
+          <Box sx={{ display: 'flex', alignItems: 'center', width: '100%', mb: 2 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flex: 1 }}>
+              <Checkbox
+                {...getGroupSelectState(groupItems, selectedItems)}
+                onChange={() => {
+                  if (isCollapsed) return;
+                  bulkSelectItems(mostRecentIds, selectedCount !== mostRecentIds.length);
+                }}
+                sx={{ flexShrink: 0 }}
+                aria-label={`Select all events in ${groupName} section`}
+                disabled={isCollapsed}
+              />
+              <Heading as="h3" sx={{ fontSize: 1, fontWeight: 'bold', m: 0 }}>
+                {groupName}
+              </Heading>
+              <Token
+                text={selectedCount > 0 ? `${selectedCount} / ${mostRecentIds.length}` : `${mostRecentIds.length}`}
+                size="small"
+                sx={{ ml: 2, flexShrink: 0 }}
+              />
+            </Box>
+            <Button
+              variant="invisible"
+              size="small"
+              onClick={() => toggleSectionCollapse(collapseKey)}
+              className="timeline-section-collapse-button"
+              sx={{
+                fontSize: '0.75rem',
+                color: 'fg.muted',
+                flexShrink: 0,
+                '&:hover': { color: 'fg.default' },
+              }}
+              aria-label={`${isCollapsed ? 'Show' : 'Hide'} ${groupName} section`}
+            >
+              {isCollapsed ? <ChevronUpIcon size={16} /> : <ChevronDownIcon size={16} />}
+            </Button>
+          </Box>
+        </div>
+        {!isCollapsed && (
+          <div className="timeline-section-content">
+            {Object.entries(urlGroups).map(([url, items]) => {
+              const mostRecent = getMostRecent(items);
+              return (
+                <div key={url} className="timeline-group">
+                  <ItemRow
+                    item={mostRecent}
+                    onShowDescription={setSelectedItemForDialog}
+                    selected={selectedItems.has(getItemId(mostRecent))}
+                    onSelect={toggleItemSelection}
+                    showCheckbox={true}
+                    groupCount={items.length > 1 ? items.length : undefined}
+                  />
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    );
+  };
 
   return (
     <ResultsContainer
@@ -199,34 +409,32 @@ const SummaryView = memo(function SummaryView({
             showClearSearch={!!searchText}
             onClearSearch={() => setSearchText('')}
           />
-        ) : (
-          Object.entries(actionGroups).map(([groupName, groupItems]) => {
-            if (groupItems.length === 0) return null;
-            const urlGroups = groupItemsByUrl(groupItems);
-            const mostRecentIds = Object.values(urlGroups).map(items => getItemId(getMostRecent(items)));
-            const selectedCount = mostRecentIds.filter(id => selectedItems.has(id)).length;
-            const isCollapsed = collapsedSections.has(groupName);
+        ) : isMultiUser && perUserActionGroups ? (
+          // Multi-user: group by user, then by action type
+          Object.entries(perUserActionGroups).map(([login, groups]) => {
+            const userItemCount = Object.values(groups).reduce((sum, items) => sum + items.length, 0);
+            if (userItemCount === 0) return null;
+            const userCollapseKey = `@user:${login}`;
+            const isUserCollapsed = collapsedSections.has(userCollapseKey);
+            // Get first item to extract avatar URL
+            const firstItem = Object.values(groups).flat()[0];
+            const avatarUrl = firstItem?.user?.avatar_url;
 
             return (
-              <div key={groupName} className="timeline-section">
+              <div key={login} className="timeline-section" style={{ marginBottom: '1rem' }}>
                 <div className="timeline-section-header">
                   <Box sx={{ display: 'flex', alignItems: 'center', width: '100%', mb: 2 }}>
                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flex: 1 }}>
-                      <Checkbox
-                        {...getGroupSelectState(groupItems, selectedItems)}
-                        onChange={() => {
-                          if (isCollapsed) return;
-                          bulkSelectItems(mostRecentIds, selectedCount !== mostRecentIds.length);
-                        }}
-                        sx={{ flexShrink: 0 }}
-                        aria-label={`Select all events in ${groupName} section`}
-                        disabled={isCollapsed}
-                      />
-                      <Heading as="h3" sx={{ fontSize: 1, fontWeight: 'bold', m: 0 }}>
-                        {groupName}
+                      {avatarUrl ? (
+                        <Avatar src={avatarUrl} size={20} alt={login} />
+                      ) : (
+                        <PeopleIcon size={16} />
+                      )}
+                      <Heading as="h2" sx={{ fontSize: 2, fontWeight: 'bold', m: 0 }}>
+                        {login}
                       </Heading>
                       <Token
-                        text={selectedCount > 0 ? `${selectedCount} / ${mostRecentIds.length}` : `${mostRecentIds.length}`}
+                        text={`${userItemCount}`}
                         size="small"
                         sx={{ ml: 2, flexShrink: 0 }}
                       />
@@ -234,7 +442,7 @@ const SummaryView = memo(function SummaryView({
                     <Button
                       variant="invisible"
                       size="small"
-                      onClick={() => toggleSectionCollapse(groupName)}
+                      onClick={() => toggleSectionCollapse(userCollapseKey)}
                       className="timeline-section-collapse-button"
                       sx={{
                         fontSize: '0.75rem',
@@ -242,34 +450,27 @@ const SummaryView = memo(function SummaryView({
                         flexShrink: 0,
                         '&:hover': { color: 'fg.default' },
                       }}
-                      aria-label={`${isCollapsed ? 'Show' : 'Hide'} ${groupName} section`}
+                      aria-label={`${isUserCollapsed ? 'Show' : 'Hide'} ${login} section`}
                     >
-                      {isCollapsed ? <ChevronUpIcon size={16} /> : <ChevronDownIcon size={16} />}
+                      {isUserCollapsed ? <ChevronUpIcon size={16} /> : <ChevronDownIcon size={16} />}
                     </Button>
                   </Box>
                 </div>
-                {!isCollapsed && (
-                  <div className="timeline-section-content">
-                    {Object.entries(urlGroups).map(([url, items]) => {
-                      const mostRecent = getMostRecent(items);
-                      return (
-                        <div key={url} className="timeline-group">
-                          <ItemRow
-                            item={mostRecent}
-                            onShowDescription={setSelectedItemForDialog}
-                            selected={selectedItems.has(getItemId(mostRecent))}
-                            onSelect={toggleItemSelection}
-                            showCheckbox={true}
-                            groupCount={items.length > 1 ? items.length : undefined}
-                          />
-                        </div>
-                      );
-                    })}
-                  </div>
+                {!isUserCollapsed && (
+                  <Box sx={{ pl: 3 }}>
+                    {Object.entries(groups).map(([groupName, groupItems]) =>
+                      renderActionGroup(groupName, groupItems, `@user:${login}/${groupName}`)
+                    )}
+                  </Box>
                 )}
               </div>
             );
           })
+        ) : (
+          // Single-user: existing behavior
+          Object.entries(actionGroups).map(([groupName, groupItems]) =>
+            renderActionGroup(groupName, groupItems, groupName)
+          )
         )}
       </div>
 


### PR DESCRIPTION
When multiple users are entered (comma-separated), all three views
(Summary, Issues & PRs, Events) now group their content by user with
collapsible user sections showing avatar, username, and item count.

Deduplication is skipped in multi-user mode to preserve per-user items
that may share the same URL across different users' activity.

Single-user mode behavior is completely unchanged.

https://claude.ai/code/session_01CKTzchrxuW2rxEjK9Aq5FK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-user support enabling results to be grouped and displayed by contributor
  * New "Group by users" toggle appears when multiple users are configured
  * Per-user sections include collapse/expand controls, pagination, and user avatars
  * Contributor information is now prominently displayed across event, issue, and PR views

<!-- end of auto-generated comment: release notes by coderabbit.ai -->