### PR TITLE
Add gh-pages deployment pipeline with PR preview support

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: pages-${{ github.event_name }}-${{ github.event.number || github.sha }}
+  group: pages-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,16 +3,18 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
 
 permissions:
   contents: write
 
 concurrency:
-  group: pages-deploy
-  cancel-in-progress: false
+  group: pages-${{ github.event_name }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -33,6 +35,25 @@ jobs:
 
       - name: Create .nojekyll
         run: touch ./dist/.nojekyll
+
+      - name: Upload build artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: production-build
+          path: ./dist
+
+  deploy:
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: production-build
+          path: ./dist
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,59 +1,42 @@
-name: Deploy PWA to GitHub Pages
+name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+    branches: [main]
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
-  group: "pages"
+  group: pages-deploy
   cancel-in-progress: false
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
-    
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '18'
-        cache: 'npm'
-        
-    - name: Install dependencies
-      run: npm ci
-      
-    - name: Build PWA
-      run: npm run build
-      
-    - name: Create .nojekyll file
-      run: touch ./dist/.nojekyll
-      
-    - name: Setup Pages
-      uses: actions/configure-pages@v4
-      
-    - name: Upload artifact
-      uses: actions/upload-pages-artifact@v3
-      with:
-        path: './dist'
 
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Create .nojekyll
+        run: touch ./dist/.nojekyll
+
       - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4 
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          keep_files: true

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,52 @@
+name: PR Preview
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: pr-preview-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        if: github.event.action != 'closed'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        if: github.event.action != 'closed'
+        run: npm ci
+
+      - name: Build for preview
+        if: github.event.action != 'closed'
+        run: npm run build
+        env:
+          VITE_BASE_PATH: /git-vegas/pr-preview/pr-${{ github.event.number }}/
+          VITE_SCOPE: /git-vegas/pr-preview/pr-${{ github.event.number }}/
+          VITE_START_URL: /git-vegas/pr-preview/pr-${{ github.event.number }}/
+
+      - name: Create .nojekyll
+        if: github.event.action != 'closed'
+        run: touch ./dist/.nojekyll
+
+      - name: Deploy PR Preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./dist
+          umbrella-dir: pr-preview
+          action: auto

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   preview:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 
     steps:

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,25 +1,36 @@
 #!/bin/bash
 
+# GitVegas Deployment Pipeline
+#
+# Production deployments happen automatically via GitHub Actions when
+# pushing to the main branch. PR preview deployments are created
+# automatically when opening or updating a pull request.
+#
+# This script is for local builds and manual gh-pages deployment.
+
+set -e
+
 # Build the project
 echo "Building the project..."
 npm run build
 
-# Navigate to the dist directory
-cd dist
-
 # Create .nojekyll file to ensure GitHub Pages serves the PWA correctly
-echo "Creating .nojekyll file for GitHub Pages..."
-touch .nojekyll
+touch ./dist/.nojekyll
 
-# Add CNAME if you have a custom domain (optional)
-# echo "your-domain.com" > CNAME
-
-echo "✅ Build complete! Deploy the dist/ folder to GitHub Pages."
 echo ""
-echo "🚀 Your PWA is ready with:"
-echo "  • Offline support with service worker"
-echo "  • App install capability"  
-echo "  • Cached GitHub API responses"
-echo "  • Offline banner for user feedback"
+echo "Build complete!"
 echo ""
-echo "📱 Users can install this as a desktop/mobile app!" 
+echo "Deployment options:"
+echo ""
+echo "  Automatic (recommended):"
+echo "    Push to main     -> production deployment to GitHub Pages"
+echo "    Open a PR        -> preview deployment at /pr-preview/pr-<number>/"
+echo ""
+echo "  Manual:"
+echo "    npm run deploy   -> deploys dist/ via gh-pages package"
+echo ""
+echo "PWA features included:"
+echo "  - Offline support with service worker"
+echo "  - App install capability"
+echo "  - Cached GitHub API responses"
+echo "  - Offline banner for user feedback"


### PR DESCRIPTION
Split deployment into two workflows:
- deploy.yml: production deployment on push to main using
  peaceiris/actions-gh-pages with keep_files to preserve previews
- pr-preview.yml: automatic PR preview deployments to
  /pr-preview/pr-<number>/ using rossjrw/pr-preview-action,
  with automatic cleanup on PR close

The PR preview workflow leverages the existing VITE_BASE_PATH env var
to build with the correct base path for each preview subdirectory.

https://claude.ai/code/session_01K7Zr3qqq3S12eDnou4ySBU